### PR TITLE
Add support for Label Styles V1 like

### DIFF
--- a/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
@@ -69,8 +69,11 @@ module App =
                         )
 
                     Button("Increment", Increment)
+                        .style(
+                            createStyleFor [ Button.BackgroundColorProperty, box Color.Green
+                                             Button.TextColorProperty, box Color.White ]
+                            )
                         .automationId("IncrementButton")
-                        .textColor(Color.Red)
 
                     Button("Decrement", Decrement)
                         .automationId("DecrementButton")

--- a/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
@@ -41,6 +41,12 @@ module App =
     let init () =
         initModel (), []
 
+    let createStyleFor<'T when 'T :> BindableObject> setters =
+        let style = Style(typeof<'T>)
+        for property, value in setters do
+            style.Setters.Add(Setter(Property = property, Value = value))
+        style
+
     let update msg model =
         match msg with
         | Increment -> { model with Count = model.Count + model.Step }, []
@@ -57,6 +63,10 @@ module App =
                     Label(string model.Count)
                         .automationId("CountLabel")
                         .centerTextHorizontal()
+                        .style (
+                            createStyleFor [ Label.TextColorProperty, box Color.Green
+                                             Label.FontSizeProperty, box 24. ]
+                        )
 
                     Button("Increment", Increment)
                         .automationId("IncrementButton")

--- a/src/Fabulous.XamarinForms/WidgetExtensions.fs
+++ b/src/Fabulous.XamarinForms/WidgetExtensions.fs
@@ -84,7 +84,11 @@ type AdditionalViewExtensions =
     [<Extension>]
     static member inline centerTextHorizontal(this: Label<_>) =
         this.AddScalarAttribute(Label.HorizontalTextAlignment.WithValue(TextAlignment.Center))
-        
+
+    [<Extension>]
+    static member inline style(this: Label<'msg>, style: Xamarin.Forms.Style) =
+        this.AddScalarAttribute(Label.Style.WithValue(style))
+
     [<Extension>]
     static member inline centerTextVertical(this: Label<_>) =
         this.AddScalarAttribute(Label.VerticalTextAlignment.WithValue(TextAlignment.Center))

--- a/src/Fabulous.XamarinForms/WidgetExtensions.fs
+++ b/src/Fabulous.XamarinForms/WidgetExtensions.fs
@@ -86,8 +86,8 @@ type AdditionalViewExtensions =
         this.AddScalarAttribute(Label.HorizontalTextAlignment.WithValue(TextAlignment.Center))
 
     [<Extension>]
-    static member inline style(this: Label<'msg>, style: Xamarin.Forms.Style) =
-        this.AddScalarAttribute(Label.Style.WithValue(style))
+    static member inline style(this: #IViewWidgetBuilder<'msg>, style: Xamarin.Forms.Style) =
+        this.AddScalarAttribute(NavigableElement.Style.WithValue(style))
 
     [<Extension>]
     static member inline centerTextVertical(this: Label<_>) =

--- a/src/Fabulous.XamarinForms/Xamarin.Forms.Core.Attributes.fs
+++ b/src/Fabulous.XamarinForms/Xamarin.Forms.Core.Attributes.fs
@@ -50,6 +50,7 @@ module View =
 
 module Label =
     let Text = Attributes.defineBindable<string> Xamarin.Forms.Label.TextProperty
+    let Style = Attributes.defineBindable<Style> Xamarin.Forms.Label.StyleProperty
     let HorizontalTextAlignment = Attributes.defineBindable<TextAlignment> Xamarin.Forms.Label.HorizontalTextAlignmentProperty
     let VerticalTextAlignment = Attributes.defineBindable<TextAlignment> Xamarin.Forms.Label.VerticalTextAlignmentProperty
     let FontSize = Attributes.defineBindable<double> Xamarin.Forms.Label.FontSizeProperty

--- a/src/Fabulous.XamarinForms/Xamarin.Forms.Core.Attributes.fs
+++ b/src/Fabulous.XamarinForms/Xamarin.Forms.Core.Attributes.fs
@@ -3,7 +3,6 @@
 open Fabulous
 open Fabulous.XamarinForms
 open Xamarin.Forms
-open System.Collections.Generic
 
 module Application =
     let MainPage = Attributes.defineWidget ViewNode.getViewNode "Application_MainPage" (fun target -> (target :?> Xamarin.Forms.Application).MainPage) (fun target value -> (target :?> Xamarin.Forms.Application).MainPage <- unbox value)
@@ -42,6 +41,9 @@ module VisualElement =
     let Width = Attributes.defineBindable<float> Xamarin.Forms.VisualElement.WidthRequestProperty
     let IsVisible = Attributes.defineBindable<bool> Xamarin.Forms.VisualElement.IsVisibleProperty
 
+module NavigableElement =
+    let Style = Attributes.defineBindable<Style> Xamarin.Forms.NavigableElement.StyleProperty
+
 module View =
     let HorizontalOptions = Attributes.defineBindable<LayoutOptions> Xamarin.Forms.View.HorizontalOptionsProperty
     let VerticalOptions = Attributes.defineBindable<LayoutOptions> Xamarin.Forms.View.VerticalOptionsProperty
@@ -50,7 +52,6 @@ module View =
 
 module Label =
     let Text = Attributes.defineBindable<string> Xamarin.Forms.Label.TextProperty
-    let Style = Attributes.defineBindable<Style> Xamarin.Forms.Label.StyleProperty
     let HorizontalTextAlignment = Attributes.defineBindable<TextAlignment> Xamarin.Forms.Label.HorizontalTextAlignmentProperty
     let VerticalTextAlignment = Attributes.defineBindable<TextAlignment> Xamarin.Forms.Label.VerticalTextAlignmentProperty
     let FontSize = Attributes.defineBindable<double> Xamarin.Forms.Label.FontSizeProperty


### PR DESCRIPTION
This PR Adds initial support for  #10  . This add a v1 like way of defining styles. 

The original idea was to have a dedicated widgets like LabelStyle(), but for this there are some changes required on how Fabulous handles that. 

I suggest we support both  : 

` style(myStyle)` This PR
` .style(
       LabelStyle()
          .textColor
    )`

Happy to try and and achieve the second one with some assistance  😀