### PR TITLE
WIP started reworking MapMsg, should work e2e but haven't figured out a couple of details yet

### DIFF
--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -227,9 +227,17 @@ module MapViewTests =
     let view model =
         Stack(
             [
-                View.map mapMsg (Button("+1", AddOne).automationId("add"))
+                View.map
+                    mapMsg
+                    (Button("+1", AddOne)
+                        .automationId("add")
+                        .textColor("red"))
+
+                Label(model.ToString())
+                    .automationId("label")
+                    .textColor("blue")
+
                 View.map mapMsg (Button("-2", RemoveTwo).automationId("remove"))
-                Label(model.ToString()).automationId("label")
             ]
         )
 

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -1,6 +1,5 @@
 module Fabulous.Tests
 
-open Fabulous.Reconciler
 open NUnit.Framework
 
 
@@ -127,7 +126,7 @@ module SimpleStackTests =
     let view model =
         Stack(
             model
-            |> List.map(fun (id, text) -> (Label(text).automationId(id.ToString())).cast())
+            |> List.map(fun (id, text) -> (Label(text).automationId(id.ToString())))
         )
             .automationId("stack")
 
@@ -228,8 +227,8 @@ module MapViewTests =
     let view model =
         Stack(
             [
-                Widget.map mapMsg (Button("+1", AddOne).automationId("add"))
-                Widget.map mapMsg (Button("-2", RemoveTwo).automationId("remove"))
+                View.map mapMsg (Button("+1", AddOne).automationId("add"))
+                View.map mapMsg (Button("-2", RemoveTwo).automationId("remove"))
                 Label(model.ToString()).automationId("label")
             ]
         )
@@ -246,19 +245,12 @@ module MapViewTests =
 
         let addBtn = find<TestButton> tree "add"
         let removeBtn = find<TestButton> tree "remove"
-        let label = find<TestLabel> tree "label"
+        let label = find<TestLabel> tree "label" :> IText
 
-        Assert.AreEqual(label.Text, "0")
+        Assert.AreEqual("0", label.Text)
 
         addBtn.Press()
-        Assert.AreEqual(label.Text, "1")
+        Assert.AreEqual("1", label.Text)
 
         removeBtn.Press()
-        Assert.AreEqual(label.Text, "-1")
-
-
-//
-//
-//    [<Test>]
-//    let dependsOnTests ()= ()
-//
+        Assert.AreEqual("-1", label.Text)

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -168,13 +168,19 @@ module SimpleStackTests =
 
         // modify the initial one
         instance.ProcessMessage(ChangeText(1, "just 1"))
-        let label = stack.Children.[1] :?> TestLabel :> IText
+
+        let label =
+            stack.Children.[1] :?> TestLabel :> IText
+
         Assert.AreEqual(label.Text, "just 1")
 
         // delete the one in front
         instance.ProcessMessage(Delete 2)
         Assert.AreEqual(stack.Children.Count, 1)
-        let label = stack.Children.[0] :?> TestLabel :> IText
+
+        let label =
+            stack.Children.[0] :?> TestLabel :> IText
+
         Assert.AreEqual(label.Text, "just 1")
 
 
@@ -201,56 +207,56 @@ module SimpleStackTests =
 //        Assert.AreEqual([], res, "this should fail for now, not a real test")
 //        ()
 //
-//module MapViewTests =
-//    type ParentMsg = Add of int
-//
-//    type ChildMsg =
-//        | AddOne
-//        | RemoveTwo
-//
-//    type Model = int
-//
-//    let update msg model =
-//        match msg with
-//        | Add value -> model + value
-//
-//    let mapMsg childMsg =
-//        match childMsg with
-//        | AddOne -> Add 1
-//        | RemoveTwo -> Add -2
-//
-//    let view model =
-//        Stack(
-//            [
-//                View.map mapMsg (Button("+1", AddOne).automationId("add"))
-//                View.map mapMsg (Button("-2", RemoveTwo).automationId("remove"))
-//                Label(model.ToString()).automationId("label")
-//            ]
-//        )
-//
-//    let init () = 0
-//
-//    [<Test>]
-//    let SketchAPI () =
-//        let program =
-//            StatefulWidget.mkSimpleView init update view
-//
-//        let instance = Run.Instance program
-//        let tree = (instance.Start())
-//
-//        let addBtn = find<TestButton> tree "add"
-//        let removeBtn = find<TestButton> tree "remove"
-//        let label = find<TestLabel> tree "label"
-//
-//        Assert.AreEqual(label.Text, "0")
-//
-//        addBtn.Press()
-//        Assert.AreEqual(label.Text, "1")
-//
-//        removeBtn.Press()
-//        Assert.AreEqual(label.Text, "-1")
-//
-//
+module MapViewTests =
+    type ParentMsg = Add of int
+
+    type ChildMsg =
+        | AddOne
+        | RemoveTwo
+
+    type Model = int
+
+    let update msg model =
+        match msg with
+        | Add value -> model + value
+
+    let mapMsg childMsg =
+        match childMsg with
+        | AddOne -> Add 1
+        | RemoveTwo -> Add -2
+
+    let view model =
+        Stack(
+            [
+                Widget.map mapMsg (Button("+1", AddOne).automationId("add"))
+                Widget.map mapMsg (Button("-2", RemoveTwo).automationId("remove"))
+                Label(model.ToString()).automationId("label")
+            ]
+        )
+
+    let init () = 0
+
+    [<Test>]
+    let SketchAPI () =
+        let program =
+            StatefulWidget.mkSimpleView init update view
+
+        let instance = Run.Instance program
+        let tree = (instance.Start())
+
+        let addBtn = find<TestButton> tree "add"
+        let removeBtn = find<TestButton> tree "remove"
+        let label = find<TestLabel> tree "label"
+
+        Assert.AreEqual(label.Text, "0")
+
+        addBtn.Press()
+        Assert.AreEqual(label.Text, "1")
+
+        removeBtn.Press()
+        Assert.AreEqual(label.Text, "-1")
+
+
 //
 //
 //    [<Test>]

--- a/src/Fabulous.Tests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/TestUI.Attributes.fs
@@ -8,7 +8,7 @@ module Attributes =
     let definePressable name =
         let key = AttributeDefinitionStore.getNextKey()
 
-        let definition: ScalarAttributeDefinition<_, _> =
+        let definition: ScalarAttributeDefinition<obj, obj> =
             {
                 Key = key
                 Name = name
@@ -33,8 +33,8 @@ module Attributes =
 
                         | ValueSome msg ->
                             let handler () =
-                                (viewNodeData.ViewNode :> IViewNode)
-                                    .Context.Dispatch(msg)
+                                let node = (viewNodeData.ViewNode :> IViewNode)
+                                Attributes.dispatchMsgOnViewNode node msg
 
                             let handlerId = btn.AddPressListener handler
                             viewNodeData.SetHandler<int>(key, ValueSome handlerId)

--- a/src/Fabulous.Tests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/TestUI.Attributes.fs
@@ -15,7 +15,7 @@ module Attributes =
                 Convert = id
                 Compare = ScalarAttributeComparers.noCompare
                 UpdateTarget =
-                    fun (newValueOpt, target) ->
+                    fun (newValueOpt, _viewNode, target) ->
 
                         let viewNodeData =
                             (target :?> TestViewElement)

--- a/src/Fabulous.Tests/TestUI.Platform.fs
+++ b/src/Fabulous.Tests/TestUI.Platform.fs
@@ -50,6 +50,6 @@ type TestButton() =
         member this.AddPressListener(handler) =
             handlers.Add(counter, handler)
             counter <- counter + 1
-            counter
+            counter - 1
 
         member this.RemovePressListener(id) = handlers.Remove(id) |> ignore

--- a/src/Fabulous.Tests/TestUI.ViewUpdaters.fs
+++ b/src/Fabulous.Tests/TestUI.ViewUpdaters.fs
@@ -38,15 +38,15 @@ open Tests.TestUI_ViewNode
 //            navigationPage.PushAsync(page) |> ignore
 
 
-let updateText (newValueOpt: string voption, target: obj) =
+let updateText (newValueOpt: string voption, _viewNode, target: obj) =
     let textElement = target :?> IText
     textElement.Text <- ValueOption.defaultValue "" newValueOpt
 
-let updateTextColor (newValueOpt: string voption, target: obj) =
+let updateTextColor (newValueOpt: string voption, _viewNode, target: obj) =
     let textElement = target :?> IText
     textElement.TextColor <- ValueOption.defaultValue "" newValueOpt
 
-let updateAutomationId (newValueOpt: string voption, target: obj) =
+let updateAutomationId (newValueOpt: string voption, _viewNode, target: obj) =
     let el = target :?> TestViewElement
     el.AutomationId <- ValueOption.defaultValue "" newValueOpt
 
@@ -86,4 +86,4 @@ let updateContainerChildren (newValueOpt: Widget [] voption, target: obj) =
         let viewNode = ViewNode.getViewNode target
 
         for widget in widgets do
-            container.Children.Add(Helpers.createViewForWidget viewNode.Context widget :?> TestViewElement)
+            container.Children.Add(Helpers.createViewForWidget viewNode widget :?> TestViewElement)

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -108,13 +108,15 @@ module ViewHelpers =
 
 
 //-----MARKERS-----------
-type TestLabelMarker =
-    class
+type TextMarker =
+    interface
     end
 
+type TestLabelMarker =
+    inherit TextMarker
+
 type TestButtonMarker =
-    class
-    end
+    inherit TextMarker
 
 type TestStackMarker =
     class
@@ -128,15 +130,12 @@ type WidgetExtensions() =
     static member inline automationId(this: WidgetBuilder<'msg, 'marker>, value: string) =
         this.AddScalarAttribute(Attributes.Automation.AutomationId.WithValue(value))
 
-    //    [<Extension>]
-//    static member inline cast<'msg>(this: IWidgetBuilder<'msg>) = this
-
     [<Extension>]
-    static member inline textColor<'msg>(this: WidgetBuilder<'msg, TestLabelMarker>, value: string) =
-        this.AddScalarAttribute(Attributes.TextStyle.TextColor.WithValue(value))
-
-    [<Extension>]
-    static member inline textColor<'msg>(this: WidgetBuilder<'msg, TestButtonMarker>, value: string) =
+    static member inline textColor<'msg, 'marker when 'marker :> TextMarker>
+        (
+            this: WidgetBuilder<'msg, 'marker>,
+            value: string
+        ) =
         this.AddScalarAttribute(Attributes.TextStyle.TextColor.WithValue(value))
 
 

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -32,7 +32,7 @@ module Attributes =
             bindableProperty.PropertyName
             convert
             compare
-            (fun (newValueOpt, target) ->
+            (fun (newValueOpt, _node, target) ->
                 match newValueOpt with
                 | ValueNone -> (target :?> BindableObject).ClearValue(bindableProperty)
                 | ValueSome v -> (target :?> BindableObject).SetValue(bindableProperty, v)
@@ -46,7 +46,7 @@ module Attributes =
             bindableProperty.PropertyName
             id
             ScalarAttributeComparers.equalityCompare
-            (fun (newValueOpt, target) ->
+            (fun (newValueOpt, _node, target) ->
                 match newValueOpt with
                 | ValueNone -> (target :?> BindableObject).ClearValue(bindableProperty)
                 | ValueSome { Light = light; Dark = ValueNone } -> (target :?> BindableObject).SetValue(bindableProperty, light)

--- a/src/Fabulous.XamarinForms/ViewUpdaters.fs
+++ b/src/Fabulous.XamarinForms/ViewUpdaters.fs
@@ -4,7 +4,7 @@ open Fabulous
 open Xamarin.Forms
 
 module ViewUpdaters =
-    let updateSliderMinMax (newValueOpt: (float * float) voption, target: obj) =
+    let updateSliderMinMax (newValueOpt: (float * float) voption, _viewNode, target: obj) =
         let slider = target :?> Slider
         match newValueOpt with
         | ValueNone ->
@@ -19,7 +19,7 @@ module ViewUpdaters =
                 slider.SetValue(Slider.MinimumProperty, min)
                 slider.SetValue(Slider.MaximumProperty, max)
 
-    let updateGridColumnDefinitions (newValueOpt: Dimension[] voption, target: obj) =
+    let updateGridColumnDefinitions (newValueOpt: Dimension[] voption, _viewNode, target: obj) =
         let grid = target :?> Grid
         match newValueOpt with
         | ValueNone -> grid.ColumnDefinitions.Clear()
@@ -36,7 +36,7 @@ module ViewUpdaters =
 
                 grid.ColumnDefinitions.Add(ColumnDefinition(Width = gridLength))
 
-    let updateGridRowDefinitions (newValueOpt: Dimension[] voption, target: obj) =
+    let updateGridRowDefinitions (newValueOpt: Dimension[] voption, _viewNode, target: obj) =
         let grid = target :?> Grid
         match newValueOpt with
         | ValueNone -> grid.RowDefinitions.Clear()
@@ -64,7 +64,7 @@ module ViewUpdaters =
             match diff with
             | WidgetCollectionItemChange.Insert (index, widget) ->
                 if index >= pages.Length then
-                    let page = Helpers.createViewForWidget viewNode.Context widget :?> Page
+                    let page = Helpers.createViewForWidget viewNode widget :?> Page
                     navigationPage.PushAsync(page) |> ignore
                 else
                     let temp = System.Collections.Generic.Stack<Xamarin.Forms.Page>()
@@ -73,7 +73,7 @@ module ViewUpdaters =
                         temp.Push(pages.[i])
                         navigationPage.PopAsync() |> ignore
                     
-                    let page = Helpers.createViewForWidget viewNode.Context widget :?> Page
+                    let page = Helpers.createViewForWidget viewNode widget :?> Page
                     navigationPage.PushAsync(page, false) |> ignore
                     
                     while temp.Count > 0  do
@@ -89,7 +89,7 @@ module ViewUpdaters =
             | WidgetCollectionItemChange.Replace (index, widget) ->
                 if index = pages.Length - 1 then
                     navigationPage.PopAsync() |> ignore
-                    let page = Helpers.createViewForWidget viewNode.Context widget :?> Page
+                    let page = Helpers.createViewForWidget viewNode widget :?> Page
                     navigationPage.PushAsync(page) |> ignore
                 else
                     let temp = System.Collections.Generic.Stack<Xamarin.Forms.Page>()
@@ -98,7 +98,7 @@ module ViewUpdaters =
                         temp.Push(pages.[i])
                         navigationPage.PopAsync() |> ignore
                     
-                    let page = Helpers.createViewForWidget viewNode.Context widget :?> Page
+                    let page = Helpers.createViewForWidget viewNode widget :?> Page
                     navigationPage.PushAsync(page, false) |> ignore
                     
                     while temp.Count > 1 do
@@ -117,7 +117,7 @@ module ViewUpdaters =
                     while temp.Count > 1 do
                         navigationPage.PushAsync(temp.Pop(), false) |> ignore
 
-    let updateNavigationPagePages (newValueOpt: Widget[] voption, target: obj) =
+    let updateNavigationPagePages (newValueOpt: Widget[] voption, _viewNode, target: obj) =
         let navigationPage = target :?> NavigationPage
         navigationPage.PopToRootAsync(false) |> ignore
 
@@ -126,5 +126,5 @@ module ViewUpdaters =
         | ValueSome widgets ->
             let viewNode = ViewNode.getViewNode target
             for widget in widgets do
-                let page = Helpers.createViewForWidget viewNode.Context widget :?> Page
+                let page = Helpers.createViewForWidget viewNode widget :?> Page
                 navigationPage.PushAsync(page) |> ignore

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -6,45 +6,63 @@ open Fabulous
 open Fabulous.XamarinForms
 
 type IWidgetBuilder =
-    abstract Compile: unit -> Widget
+    abstract Compile : unit -> Widget
 
-type IWidgetBuilder<'msg> = inherit IWidgetBuilder
-type IApplicationWidgetBuilder<'msg> = inherit IWidgetBuilder<'msg>
-type IPageWidgetBuilder<'msg> = inherit IWidgetBuilder<'msg>
-type IViewWidgetBuilder<'msg> = inherit IWidgetBuilder<'msg>
-type ILayoutWidgetBuilder<'msg> = inherit IViewWidgetBuilder<'msg>
-type ICellWidgetBuilder<'msg> = inherit IWidgetBuilder<'msg>
-type IGestureRecognizerWidgetBuilder<'msg> = inherit IWidgetBuilder<'msg>
-type IMenuItemWidgetBuilder<'msg> = inherit IWidgetBuilder<'msg>
-type IToolbarItemWidgetBuilder<'msg> = inherit IMenuItemWidgetBuilder<'msg>
+type IWidgetBuilder<'msg> =
+    inherit IWidgetBuilder
+
+type IApplicationWidgetBuilder<'msg> =
+    inherit IWidgetBuilder<'msg>
+
+type IPageWidgetBuilder<'msg> =
+    inherit IWidgetBuilder<'msg>
+
+type IViewWidgetBuilder<'msg> =
+    inherit IWidgetBuilder<'msg>
+
+type ILayoutWidgetBuilder<'msg> =
+    inherit IViewWidgetBuilder<'msg>
+
+type ICellWidgetBuilder<'msg> =
+    inherit IWidgetBuilder<'msg>
+
+type IGestureRecognizerWidgetBuilder<'msg> =
+    inherit IWidgetBuilder<'msg>
+
+type IMenuItemWidgetBuilder<'msg> =
+    inherit IWidgetBuilder<'msg>
+
+type IToolbarItemWidgetBuilder<'msg> =
+    inherit IMenuItemWidgetBuilder<'msg>
 
 module Widgets =
-    let register<'T  when 'T :> Xamarin.Forms.BindableObject and 'T : (new: unit -> 'T)>() =
+    let register<'T when 'T :> Xamarin.Forms.BindableObject and 'T: (new : unit -> 'T)> () =
         let key = WidgetDefinitionStore.getNextKey()
+
         let definition =
-            { Key = key
-              Name = typeof<'T>.Name
-              CreateView = fun (widget, parentContext) ->
-                let name = typeof<'T>.Name
-                printfn $"Creating view for {name}"
+            {
+                Key = key
+                Name = typeof<'T>.Name
+                CreateView =
+                    fun (widget, context) ->
+                        let name = typeof<'T>.Name
+                        printfn $"Creating view for {name}"
 
-                let mapMsg = widget.GetScalarOrDefault<obj -> obj>(Fabulous.Attributes.MapMsg.Key, id)
-                let context =
-                    { parentContext with
-                        Dispatch = mapMsg >> parentContext.Dispatch
-                        CanReuseView = parentContext.CanReuseView }
+                        let view = new 'T()
+                        let weakReference = WeakReference(view)
 
-                let view = new 'T()
-                let weakReference = WeakReference(view)
-                let viewNode = ViewNode(key, context, mapMsg, weakReference)
-                view.SetValue(ViewNode.ViewNodeProperty, viewNode)
+                        let viewNode =
+                            ViewNode(key, context, weakReference)
 
-                Reconciler.update ViewNode.getViewNode context.CanReuseView ValueNone widget view
+                        view.SetValue(ViewNode.ViewNodeProperty, viewNode)
 
-                box view }
-        
+                        Reconciler.update ViewNode.getViewNode context.CanReuseView ValueNone widget view
+
+                        box view
+            }
+
         WidgetDefinitionStore.set key definition
         key
 
-    let inline map (fn: 'oldMsg -> 'newMsg) (this: ^T when ^T :> IWidgetBuilder<'oldMsg>) : ^U when ^U :> IWidgetBuilder<'newMsg> =
-        (^T: (member MapMsg: ('oldMsg -> 'newMsg) -> 'U) (this, fn))
+    let inline map (fn: 'oldMsg -> 'newMsg) (this: ^T :> IWidgetBuilder<'oldMsg>) : ^U :> IWidgetBuilder<'newMsg> =
+        (^T: (member MapMsg : ('oldMsg -> 'newMsg) -> 'U) (this, fn))

--- a/src/Fabulous.XamarinForms/Xamarin.Forms.Core.Attributes.fs
+++ b/src/Fabulous.XamarinForms/Xamarin.Forms.Core.Attributes.fs
@@ -14,11 +14,11 @@ module Page =
     let Padding = Attributes.defineBindable<Thickness> Xamarin.Forms.Page.PaddingProperty
     let Title = Attributes.defineBindable<string> Xamarin.Forms.Page.TitleProperty
     let ToolbarItems = Attributes.defineWidgetCollection<Xamarin.Forms.ToolbarItem> ViewNode.getViewNode "Page_ToolbarItems" (fun target -> (target :?> Xamarin.Forms.Page).ToolbarItems)
-    let Appearing = Attributes.defineEventNoArg ViewNode.getViewNode "Page_Appearing" (fun target -> (target :?> Xamarin.Forms.Page).Appearing)
+    let Appearing = Attributes.defineEventNoArg "Page_Appearing" (fun target -> (target :?> Xamarin.Forms.Page).Appearing)
 
 module ContentPage =
     let Content = Attributes.defineBindableWidget Xamarin.Forms.ContentPage.ContentProperty
-    let SizeAllocated = Attributes.defineEvent<SizeAllocatedEventArgs> ViewNode.getViewNode "ContentPage_SizeAllocated" (fun target -> (target :?> FabulousContentPage).SizeAllocated)
+    let SizeAllocated = Attributes.defineEvent<SizeAllocatedEventArgs> "ContentPage_SizeAllocated" (fun target -> (target :?> FabulousContentPage).SizeAllocated)
 
 module Layout =
     let Padding = Attributes.defineBindable<Thickness> Xamarin.Forms.Layout.PaddingProperty
@@ -62,23 +62,23 @@ module Label =
 
 module Button =
     let Text = Attributes.defineBindable<string> Xamarin.Forms.Button.TextProperty
-    let Clicked = Attributes.defineEventNoArg ViewNode.getViewNode "Button_Clicked" (fun target -> (target :?> Xamarin.Forms.Button).Clicked)
+    let Clicked = Attributes.defineEventNoArg "Button_Clicked" (fun target -> (target :?> Xamarin.Forms.Button).Clicked)
     let TextColor = Attributes.defineAppThemeBindable<Color> Xamarin.Forms.Button.TextColorProperty
     let FontSize = Attributes.defineBindable<double> Xamarin.Forms.Button.FontSizeProperty
     
 module ImageButton =
     let Source = Attributes.defineBindable<ImageSource> Xamarin.Forms.ImageButton.SourceProperty
     let Aspect = Attributes.defineBindable<Aspect> Xamarin.Forms.ImageButton.AspectProperty
-    let Clicked = Attributes.defineEventNoArg ViewNode.getViewNode "ImageButton_Clicked" (fun target -> (target :?> Xamarin.Forms.ImageButton).Clicked)
+    let Clicked = Attributes.defineEventNoArg "ImageButton_Clicked" (fun target -> (target :?> Xamarin.Forms.ImageButton).Clicked)
 
 module Switch =
     let IsToggled = Attributes.defineBindable<bool> Xamarin.Forms.Switch.IsToggledProperty
-    let Toggled = Attributes.defineEvent<ToggledEventArgs> ViewNode.getViewNode "Switch_Toggled" (fun target -> (target :?> Xamarin.Forms.Switch).Toggled)
+    let Toggled = Attributes.defineEvent<ToggledEventArgs> "Switch_Toggled" (fun target -> (target :?> Xamarin.Forms.Switch).Toggled)
 
 module Slider =
     let MinimumMaximum = Attributes.define<float * float> "Slider_MinimumMaximum" ViewUpdaters.updateSliderMinMax
     let Value = Attributes.defineBindable<float> Xamarin.Forms.Slider.ValueProperty
-    let ValueChanged = Attributes.defineEvent<ValueChangedEventArgs> ViewNode.getViewNode "Slider_ValueChanged" (fun target -> (target :?> Xamarin.Forms.Slider).ValueChanged)
+    let ValueChanged = Attributes.defineEvent<ValueChangedEventArgs> "Slider_ValueChanged" (fun target -> (target :?> Xamarin.Forms.Slider).ValueChanged)
 
 module ActivityIndicator =
     let IsRunning = Attributes.defineBindable<bool> Xamarin.Forms.ActivityIndicator.IsRunningProperty
@@ -88,7 +88,7 @@ module ContentView =
 
 module RefreshView =
     let IsRefreshing = Attributes.defineBindable<bool> Xamarin.Forms.RefreshView.IsRefreshingProperty
-    let Refreshing = Attributes.defineEventNoArg ViewNode.getViewNode "RefreshView_Refreshing" (fun target -> (target :?> Xamarin.Forms.RefreshView).Refreshing)
+    let Refreshing = Attributes.defineEventNoArg "RefreshView_Refreshing" (fun target -> (target :?> Xamarin.Forms.RefreshView).Refreshing)
 
 module ScrollView =
     let Content = Attributes.defineWidget ViewNode.getViewNode "ScrollView_Content" (fun target -> (target :?> Xamarin.Forms.ScrollView).Content) (fun target value -> (target :?> Xamarin.Forms.ScrollView).Content <- unbox value)
@@ -116,31 +116,31 @@ module NavigationPage =
     let BarTextColor = Attributes.defineBindable<Color> Xamarin.Forms.NavigationPage.BarTextColorProperty
     let HasNavigationBar = Attributes.defineBindable<bool> Xamarin.Forms.NavigationPage.HasNavigationBarProperty
     let HasBackButton = Attributes.defineBindable<bool> Xamarin.Forms.NavigationPage.HasBackButtonProperty
-    let Popped = Attributes.defineEvent<NavigationEventArgs> ViewNode.getViewNode "NavigationPage_Popped" (fun target -> (target :?> Xamarin.Forms.NavigationPage).Popped)
+    let Popped = Attributes.defineEvent<NavigationEventArgs> "NavigationPage_Popped" (fun target -> (target :?> Xamarin.Forms.NavigationPage).Popped)
 
 module Entry =
     let Text = Attributes.defineBindable<string> Xamarin.Forms.Entry.TextProperty
-    let TextChanged = Attributes.defineEvent<TextChangedEventArgs> ViewNode.getViewNode "Entry_TextChanged" (fun target -> (target :?> Xamarin.Forms.Entry).TextChanged)
+    let TextChanged = Attributes.defineEvent<TextChangedEventArgs> "Entry_TextChanged" (fun target -> (target :?> Xamarin.Forms.Entry).TextChanged)
     let Placeholder = Attributes.defineBindable<string> Xamarin.Forms.Entry.PlaceholderProperty
     let Keyboard = Attributes.defineBindable<Keyboard> Xamarin.Forms.Entry.KeyboardProperty
 
 module TapGestureRecognizer =
-    let Tapped = Attributes.defineEventNoArg ViewNode.getViewNode "TapGestureRecognizer_Tapped" (fun target -> (target :?> Xamarin.Forms.TapGestureRecognizer).Tapped)
+    let Tapped = Attributes.defineEventNoArg "TapGestureRecognizer_Tapped" (fun target -> (target :?> Xamarin.Forms.TapGestureRecognizer).Tapped)
 
 module SearchBar =
     let Text = Attributes.defineBindable<string> Xamarin.Forms.SearchBar.TextProperty
     let CancelButtonColor = Attributes.defineBindable<Color> Xamarin.Forms.SearchBar.CancelButtonColorProperty
-    let SearchButtonPressed = Attributes.defineEventNoArg ViewNode.getViewNode "SearchBar_SearchButtonPressed" (fun target -> (target :?> Xamarin.Forms.SearchBar).SearchButtonPressed)
+    let SearchButtonPressed = Attributes.defineEventNoArg "SearchBar_SearchButtonPressed" (fun target -> (target :?> Xamarin.Forms.SearchBar).SearchButtonPressed)
 
 module InputView =
-    let TextChanged = Attributes.defineEvent<TextChangedEventArgs> ViewNode.getViewNode "InputView_TextChanged" (fun target -> (target :?> Xamarin.Forms.InputView).TextChanged)
+    let TextChanged = Attributes.defineEvent<TextChangedEventArgs> "InputView_TextChanged" (fun target -> (target :?> Xamarin.Forms.InputView).TextChanged)
 
 module MenuItem =
     let Text = Attributes.defineBindable<string> Xamarin.Forms.MenuItem.TextProperty
-    let Clicked = Attributes.defineEventNoArg ViewNode.getViewNode "MenuItem_Clicked" (fun target -> (target :?> Xamarin.Forms.MenuItem).Clicked)
+    let Clicked = Attributes.defineEventNoArg "MenuItem_Clicked" (fun target -> (target :?> Xamarin.Forms.MenuItem).Clicked)
 
 module ToolbarItem =
-    let Order = Attributes.define<ToolbarItemOrder> "ToolbarItem_Order" (fun (newValueOpt, target) ->
+    let Order = Attributes.define<ToolbarItemOrder> "ToolbarItem_Order" (fun (newValueOpt, _viewNode, target) ->
         let toolbarItem = target :?> Xamarin.Forms.ToolbarItem
         match newValueOpt with
         | ValueNone -> toolbarItem.Order <- ToolbarItemOrder.Default

--- a/src/Fabulous/AttributeDefinitions.fs
+++ b/src/Fabulous/AttributeDefinitions.fs
@@ -1,8 +1,10 @@
 ﻿namespace Fabulous
 
+open Fabulous
+
 type IAttributeDefinition =
     abstract member Key: AttributeKey
-    abstract member UpdateTarget: newValueOpt: obj voption * target: obj -> unit
+    abstract member UpdateTarget: newValueOpt: obj voption * viewNode: IViewNode * target: obj -> unit
 
 type IScalarAttributeDefinition =
     inherit IAttributeDefinition
@@ -14,7 +16,7 @@ type ScalarAttributeDefinition<'inputType, 'modelType> =
       Name: string
       Convert: 'inputType -> 'modelType
       Compare: 'modelType * 'modelType -> ScalarAttributeComparison
-      UpdateTarget: 'modelType voption * obj -> unit }
+      UpdateTarget: 'modelType voption * IViewNode * obj -> unit }
 
     member x.WithValue(value): ScalarAttribute =
         { Key = x.Key
@@ -26,16 +28,16 @@ type ScalarAttributeDefinition<'inputType, 'modelType> =
     interface IScalarAttributeDefinition with
         member x.Key = x.Key
         member x.CompareBoxed(a, b) = x.Compare (unbox<'modelType> a, unbox<'modelType> b)
-        member x.UpdateTarget(newValueOpt, target) =
+        member x.UpdateTarget(newValueOpt, viewNode, target) =
             let newValueOpt = match newValueOpt with ValueNone -> ValueNone | ValueSome v -> ValueSome (unbox<'modelType> v)
-            x.UpdateTarget(newValueOpt, target)
+            x.UpdateTarget(newValueOpt, viewNode, target)
 
 /// Attribute definition for widget properties
 type WidgetAttributeDefinition =
     { Key: AttributeKey
       Name: string
       ApplyDiff: WidgetDiff * obj -> unit
-      UpdateTarget: Widget voption * obj -> unit }
+      UpdateTarget: Widget voption * IViewNode * obj -> unit }
 
     member x.WithValue(value: Widget): WidgetAttribute =
         { Key = x.Key
@@ -46,16 +48,16 @@ type WidgetAttributeDefinition =
 
     interface IAttributeDefinition with
         member x.Key = x.Key
-        member x.UpdateTarget(newValueOpt, target) =
+        member x.UpdateTarget(newValueOpt, viewNode, target) =
             let newValueOpt = match newValueOpt with ValueNone -> ValueNone | ValueSome v -> ValueSome (unbox<Widget> v)
-            x.UpdateTarget(newValueOpt, target)
+            x.UpdateTarget(newValueOpt, viewNode, target)
             
 /// Attribute definition for collection properties
 type WidgetCollectionAttributeDefinition =
     { Key: AttributeKey
       Name: string
       ApplyDiff: WidgetCollectionItemChange[] * obj -> unit
-      UpdateTarget: Widget[] voption * obj -> unit }
+      UpdateTarget: Widget[] voption * IViewNode * obj -> unit }
             
     member x.WithValue(value: Widget[]): WidgetCollectionAttribute =
         { Key = x.Key
@@ -66,6 +68,6 @@ type WidgetCollectionAttributeDefinition =
             
     interface IAttributeDefinition with
         member x.Key = x.Key
-        member x.UpdateTarget(newValueOpt, target) =
+        member x.UpdateTarget(newValueOpt, viewNode, target) =
             let newValueOpt = match newValueOpt with ValueNone -> ValueNone | ValueSome v -> ValueSome (unbox<Widget[]> v)
-            x.UpdateTarget(newValueOpt, target)
+            x.UpdateTarget(newValueOpt, viewNode, target)

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -2,17 +2,22 @@
 
 open System
 open System.Runtime.CompilerServices
+open Fabulous
 
 module Helpers =
-    let canReuseView (prevWidget: Widget) (currWidget: Widget) =
-        prevWidget.Key = currWidget.Key
+    let canReuseView (prevWidget: Widget) (currWidget: Widget) = prevWidget.Key = currWidget.Key
 
-    let canReuse<'T when 'T: equality> (prev: 'T) (curr: 'T) =
-        prev = curr
+    let canReuse<'T when 'T: equality> (prev: 'T) (curr: 'T) = prev = curr
 
-    let createViewForWidget (context: ViewTreeContext) (widget: Widget) =
+    let inline createViewForWidget (parent: IViewNode) (widget: Widget) =
         let widgetDefinition = WidgetDefinitionStore.get widget.Key
-        widgetDefinition.CreateView (widget, context)
+
+        let context: ViewTreeContext =
+            { parent.Context with
+                Ancestors = parent :: parent.Context.Ancestors
+            }
+
+        widgetDefinition.CreateView(widget, context)
 
 module ScalarAttributeComparers =
     let noCompare (a, b) = ScalarAttributeComparison.Different b
@@ -24,72 +29,115 @@ module ScalarAttributeComparers =
             ScalarAttributeComparison.Different b
 
 module Attributes =
-    type [<Struct>] AttributesBuilder (scalarAttributes: ScalarAttribute[], widgetAttributes: WidgetAttribute[], widgetCollectionAttributes: WidgetCollectionAttribute[]) =
+    [<Struct>]
+    type AttributesBuilder
+        (
+            scalarAttributes: ScalarAttribute [],
+            widgetAttributes: WidgetAttribute [],
+            widgetCollectionAttributes: WidgetCollectionAttribute []
+        ) =
         member x.AddScalar(attr: ScalarAttribute) =
             let attribs = scalarAttributes
-            let attribs2 = Array.zeroCreate (scalarAttributes.Length + 1)
+
+            let attribs2 =
+                Array.zeroCreate(scalarAttributes.Length + 1)
+
             Array.blit scalarAttributes 0 attribs2 0 scalarAttributes.Length
             attribs2.[scalarAttributes.Length] <- attr
             AttributesBuilder(attribs2, widgetAttributes, widgetCollectionAttributes)
 
         member x.AddWidget(attr: WidgetAttribute) =
             let attribs = widgetAttributes
-            let attribs2 = Array.zeroCreate (widgetAttributes.Length + 1)
+
+            let attribs2 =
+                Array.zeroCreate(widgetAttributes.Length + 1)
+
             Array.blit widgetAttributes 0 attribs2 0 widgetAttributes.Length
             attribs2.[widgetAttributes.Length] <- attr
             AttributesBuilder(scalarAttributes, attribs2, widgetCollectionAttributes)
 
         member x.AddWidgetCollection(attr: WidgetCollectionAttribute) =
             let attribs = widgetCollectionAttributes
-            let attribs2 = Array.zeroCreate (widgetCollectionAttributes.Length + 1)
+
+            let attribs2 =
+                Array.zeroCreate(widgetCollectionAttributes.Length + 1)
+
             Array.blit widgetCollectionAttributes 0 attribs2 0 widgetCollectionAttributes.Length
             attribs2.[widgetCollectionAttributes.Length] <- attr
             AttributesBuilder(scalarAttributes, widgetAttributes, attribs2)
-        
-        member x.AddScalars(attrs: ScalarAttribute[]) = x
-        member x.AddWidgets(attrs: WidgetAttribute[]) = x
-        member x.AddWidgetCollections(attrs: WidgetCollectionAttribute[]) = x
+
+        member x.AddScalars(attrs: ScalarAttribute []) = x
+        member x.AddWidgets(attrs: WidgetAttribute []) = x
+        member x.AddWidgetCollections(attrs: WidgetCollectionAttribute []) = x
 
         member x.TryGetScalar(key: AttributeKey) =
-            scalarAttributes |> Array.tryFind (fun attr -> attr.Key = key)
+            scalarAttributes
+            |> Array.tryFind(fun attr -> attr.Key = key)
 
         member x.Build(key) =
-            { Key = key
-              ScalarAttributes = scalarAttributes
-              WidgetAttributes = widgetAttributes
-              WidgetCollectionAttributes = widgetCollectionAttributes }
+            {
+                Key = key
+                ScalarAttributes = scalarAttributes
+                WidgetAttributes = widgetAttributes
+                WidgetCollectionAttributes = widgetCollectionAttributes
+            }
 
     /// Define a custom attribute storing any value
-    let defineScalarWithConverter<'inputType, 'modelType> name (convert: 'inputType -> 'modelType) (compare: 'modelType * 'modelType -> ScalarAttributeComparison) (updateTarget: 'modelType voption * obj -> unit) =
+    let defineScalarWithConverter<'inputType, 'modelType>
+        name
+        (convert: 'inputType -> 'modelType)
+        (compare: 'modelType * 'modelType -> ScalarAttributeComparison)
+        (updateTarget: 'modelType voption * IViewNode * obj -> unit)
+        =
         let key = AttributeDefinitionStore.getNextKey()
+
         let definition =
-            { Key = key
-              Name = name
-              Convert = convert
-              Compare = compare
-              UpdateTarget = updateTarget }
+            {
+                Key = key
+                Name = name
+                Convert = convert
+                Compare = compare
+                UpdateTarget = updateTarget
+            }
+
         AttributeDefinitionStore.set key definition
         definition
 
     /// Define a custom attribute storing a widget
-    let defineWidgetWithConverter name (applyDiff: WidgetDiff * obj -> unit) (updateTarget: Widget voption * obj -> unit) =
+    let defineWidgetWithConverter
+        name
+        (applyDiff: WidgetDiff * obj -> unit)
+        (updateTarget: Widget voption * IViewNode * obj -> unit)
+        =
         let key = AttributeDefinitionStore.getNextKey()
+
         let definition: WidgetAttributeDefinition =
-            { Key = key
-              Name = name
-              ApplyDiff = applyDiff
-              UpdateTarget = updateTarget }
+            {
+                Key = key
+                Name = name
+                ApplyDiff = applyDiff
+                UpdateTarget = updateTarget
+            }
+
         AttributeDefinitionStore.set key definition
         definition
-        
+
     /// Define a custom attribute storing a widget collection
-    let defineWidgetCollectionWithConverter name (applyDiff: WidgetCollectionItemChange[] * obj -> unit) (updateTarget: Widget[] voption * obj -> unit) =
+    let defineWidgetCollectionWithConverter
+        name
+        (applyDiff: WidgetCollectionItemChange [] * obj -> unit)
+        (updateTarget: Widget [] voption * IViewNode * obj -> unit)
+        =
         let key = AttributeDefinitionStore.getNextKey()
+
         let definition: WidgetCollectionAttributeDefinition =
-            { Key = key
-              Name = name
-              ApplyDiff = applyDiff
-              UpdateTarget = updateTarget }
+            {
+                Key = key
+                Name = name
+                ApplyDiff = applyDiff
+                UpdateTarget = updateTarget
+            }
+
         AttributeDefinitionStore.set key definition
         definition
 
@@ -98,158 +146,219 @@ module Attributes =
         let applyDiff (diff: WidgetDiff, parent) =
             let target = get parent
             let viewNode = getViewNode target
-            if diff.ScalarChanges.Length > 0 then viewNode.ApplyScalarDiff(diff.ScalarChanges)
-            if diff.WidgetChanges.Length > 0 then viewNode.ApplyWidgetDiff(diff.WidgetChanges)
-            if diff.WidgetCollectionChanges.Length > 0 then viewNode.ApplyWidgetCollectionDiff(diff.WidgetCollectionChanges)
 
-        let updateTarget (newValueOpt: Widget voption, target) = 
+            if diff.ScalarChanges.Length > 0 then
+                viewNode.ApplyScalarDiff(diff.ScalarChanges)
+
+            if diff.WidgetChanges.Length > 0 then
+                viewNode.ApplyWidgetDiff(diff.WidgetChanges)
+
+            if diff.WidgetCollectionChanges.Length > 0 then
+                viewNode.ApplyWidgetCollectionDiff(diff.WidgetCollectionChanges)
+
+        let updateTarget (newValueOpt: Widget voption, viewNode: IViewNode, target) =
             match newValueOpt with
             | ValueNone -> set target null
             | ValueSome widget ->
-                let viewNode = getViewNode target
-                let view = Helpers.createViewForWidget viewNode.Context widget
+                let view =
+                    Helpers.createViewForWidget viewNode widget
+
                 set target view
 
         defineWidgetWithConverter name applyDiff updateTarget
-        
+
     /// Define an attribute storing a collection of Widget
-    let defineWidgetCollection<'itemType> (getViewNode: obj -> IViewNode) name (getCollection: obj -> System.Collections.Generic.IList<'itemType>) =
-        let applyDiff (diffs: WidgetCollectionItemChange[], target: obj) =
+    let defineWidgetCollection<'itemType>
+        (getViewNode: obj -> IViewNode)
+        name
+        (getCollection: obj -> System.Collections.Generic.IList<'itemType>)
+        =
+        let applyDiff (diffs: WidgetCollectionItemChange [], target: obj) =
             let viewNode = getViewNode target
             let targetColl = getCollection target
-        
+
             for diff in diffs do
                 match diff with
-                | WidgetCollectionItemChange.Remove index ->
-                    targetColl.RemoveAt(index)
+                | WidgetCollectionItemChange.Remove index -> targetColl.RemoveAt(index)
                 | _ -> ()
-        
+
             for diff in diffs do
                 match diff with
                 | WidgetCollectionItemChange.Insert (index, widget) ->
-                    let view = Helpers.createViewForWidget viewNode.Context widget
+                    let view =
+                        Helpers.createViewForWidget viewNode widget
+
                     targetColl.Insert(index, unbox view)
-        
+
                 | WidgetCollectionItemChange.Update (index, widgetDiff) ->
                     let targetItem = targetColl.[index]
                     let viewNode = getViewNode targetItem
-                    if widgetDiff.ScalarChanges.Length > 0 then viewNode.ApplyScalarDiff(widgetDiff.ScalarChanges)
-                    if widgetDiff.WidgetChanges.Length > 0 then viewNode.ApplyWidgetDiff(widgetDiff.WidgetChanges)
-                    if widgetDiff.WidgetCollectionChanges.Length > 0 then viewNode.ApplyWidgetCollectionDiff(widgetDiff.WidgetCollectionChanges)
-        
+
+                    if widgetDiff.ScalarChanges.Length > 0 then
+                        viewNode.ApplyScalarDiff(widgetDiff.ScalarChanges)
+
+                    if widgetDiff.WidgetChanges.Length > 0 then
+                        viewNode.ApplyWidgetDiff(widgetDiff.WidgetChanges)
+
+                    if widgetDiff.WidgetCollectionChanges.Length > 0 then
+                        viewNode.ApplyWidgetCollectionDiff(widgetDiff.WidgetCollectionChanges)
+
                 | WidgetCollectionItemChange.Replace (index, widget) ->
-                    let view = Helpers.createViewForWidget viewNode.Context widget
+                    let view =
+                        Helpers.createViewForWidget viewNode widget
+
                     targetColl.[index] <- unbox view
-        
+
                 | _ -> ()
-        
-        let updateTarget (newValueOpt: Widget[] voption, target: obj) =
-            let viewNode = getViewNode target
+
+        let updateTarget (newValueOpt: Widget [] voption, viewNode: IViewNode, target: obj) =
             let targetColl = getCollection target
             targetColl.Clear()
-        
+
             match newValueOpt with
             | ValueNone -> ()
             | ValueSome widgets ->
                 for widget in widgets do
-                    let view = Helpers.createViewForWidget viewNode.Context widget
+                    let view =
+                        Helpers.createViewForWidget viewNode widget
+
                     targetColl.Add(unbox view)
-        
+
         defineWidgetCollectionWithConverter name applyDiff updateTarget
-        
+
     let inline define<'T when 'T: equality> name updateTarget =
         defineScalarWithConverter<'T, 'T> name id ScalarAttributeComparers.equalityCompare updateTarget
-        
-    let defineEventNoArg (getViewNode: obj -> IViewNode) name (getEvent: obj -> IEvent<EventHandler, EventArgs>) =
+
+    let dispatchMsgOnViewNode (viewNode: IViewNode) msg =
+        let inline mapMsg (node: IViewNode) (m: obj) =
+            match node.MapMsg with
+            | ValueNone -> m
+            | ValueSome fn -> fn m
+
+        let mutable msgToDispatch = mapMsg viewNode msg
+
+        let treeContext = viewNode.Context
+
+        for ancestor in treeContext.Ancestors do
+            msgToDispatch <- mapMsg ancestor msgToDispatch
+
+        treeContext.Dispatch(msgToDispatch)
+
+    let defineEventNoArg name (getEvent: obj -> IEvent<EventHandler, EventArgs>) =
         let key = AttributeDefinitionStore.getNextKey()
-        let definition : ScalarAttributeDefinition<obj,obj> =
-            { Key = key
-              Name = name
-              Convert = id
-              Compare = ScalarAttributeComparers.noCompare
-              UpdateTarget = fun (newValueOpt, target) ->
-                let event = getEvent target
-                let viewNode = getViewNode target
-        
-                match viewNode.TryGetHandler(key) with
-                | None -> ()
-                | Some handler -> event.RemoveHandler handler
-        
-                match newValueOpt with
-                | ValueNone ->
-                    viewNode.SetHandler(key, ValueNone)
-        
-                | ValueSome msg ->
-                    let handler = EventHandler(fun _ _ ->
-                        viewNode.Context.Dispatch (viewNode.MapMsg msg)
-                    )
-                    event.AddHandler handler
-                    viewNode.SetHandler(key, ValueSome handler) }
-        AttributeDefinitionStore.set key definition
-        definition
-        
-    let defineEvent<'args> (getViewNode: obj -> IViewNode) name (getEvent: obj -> IEvent<EventHandler<'args>, 'args>) =
-        let key = AttributeDefinitionStore.getNextKey()
-        let definition : ScalarAttributeDefinition<_,_> =
-            { Key = key
-              Name = name
-              Convert = id
-              Compare = ScalarAttributeComparers.noCompare
-              UpdateTarget = fun (newValueOpt: ('args -> obj) voption, target) ->
-        
-                let event = getEvent target
-                let viewNode = getViewNode target
-        
-                match viewNode.TryGetHandler(key) with
-                | None ->
-                    printfn $"No old handler for {name}"
-                | Some handler ->
-                    printfn $"Removed old handler for {name}"
-                    event.RemoveHandler handler
-        
-                match newValueOpt with
-                | ValueNone ->
-                    viewNode.SetHandler(key, ValueNone)
-        
-                | ValueSome fn ->
-                    let handler = EventHandler<'args>(fun _ args ->
-                        printfn $"Handler for {name} triggered"
-                        let r = fn args
-                        viewNode.Context.Dispatch (viewNode.MapMsg r)
-                    )
-                    viewNode.SetHandler(key, ValueSome handler)
-                    event.AddHandler handler
-                    printfn $"Added new handler for {name}"
+
+        let definition: ScalarAttributeDefinition<obj, obj> =
+            {
+                Key = key
+                Name = name
+                Convert = id
+                Compare = ScalarAttributeComparers.noCompare
+                UpdateTarget =
+                    fun (newValueOpt, viewNode, target) ->
+                        let event = getEvent target
+
+                        match viewNode.TryGetHandler(key) with
+                        | None -> ()
+                        | Some handler -> event.RemoveHandler handler
+
+                        match newValueOpt with
+                        | ValueNone -> viewNode.SetHandler(key, ValueNone)
+
+                        | ValueSome msg ->
+                            let handler =
+                                EventHandler(fun _ _ -> dispatchMsgOnViewNode viewNode msg)
+
+                            event.AddHandler handler
+                            viewNode.SetHandler(key, ValueSome handler)
             }
+
+        AttributeDefinitionStore.set key definition
+        definition
+
+    let defineEvent<'args> name (getEvent: obj -> IEvent<EventHandler<'args>, 'args>) =
+        let key = AttributeDefinitionStore.getNextKey()
+
+        let definition: ScalarAttributeDefinition<_, _> =
+            {
+                Key = key
+                Name = name
+                Convert = id
+                Compare = ScalarAttributeComparers.noCompare
+                UpdateTarget =
+                    fun (newValueOpt: ('args -> obj) voption, viewNode, target) ->
+
+                        let event = getEvent target
+
+                        match viewNode.TryGetHandler(key) with
+                        | None -> printfn $"No old handler for {name}"
+                        | Some handler ->
+                            printfn $"Removed old handler for {name}"
+                            event.RemoveHandler handler
+
+                        match newValueOpt with
+                        | ValueNone -> viewNode.SetHandler(key, ValueNone)
+
+                        | ValueSome fn ->
+                            let handler =
+                                EventHandler<'args>
+                                    (fun _ args ->
+                                        printfn $"Handler for {name} triggered"
+                                        let r = fn args
+                                        dispatchMsgOnViewNode viewNode r)
+
+                            viewNode.SetHandler(key, ValueSome handler)
+                            event.AddHandler handler
+                            printfn $"Added new handler for {name}"
+            }
+
         AttributeDefinitionStore.set key definition
         definition
 
 
-    let MapMsg = defineScalarWithConverter<obj -> obj,_> "Fabulous_MapMsg" id ScalarAttributeComparers.noCompare ignore
+    let MapMsg =
+        defineScalarWithConverter<obj -> obj, _>
+            "Fabulous_MapMsg"
+            id
+            ScalarAttributeComparers.noCompare
+            (fun (value, node, _target) -> node.MapMsg <- value)
 
 [<Extension>]
-type WidgetExtensions () =
+type WidgetExtensions() =
     [<Extension>]
     static member inline AddScalarAttribute(this: ^T, attr: ScalarAttribute) =
-        let builder = (^T : (member Builder: Attributes.AttributesBuilder) this)
+        let builder =
+            (^T: (member Builder : Attributes.AttributesBuilder) this)
+
         let newBuilder = builder.AddScalar(attr)
-        let result = (^T: (new: Attributes.AttributesBuilder -> ^T) newBuilder)
+
+        let result =
+            (^T: (new : Attributes.AttributesBuilder -> ^T) newBuilder)
+
         result
 
     [<Extension>]
-    static member inline AddScalarAttributes(this: ^T, attrs: ScalarAttribute[]) =
+    static member inline AddScalarAttributes(this: ^T, attrs: ScalarAttribute []) =
         match attrs with
-        | [||] ->
-            this
+        | [||] -> this
         | attributes ->
-            let builder = (^T : (member Builder: Attributes.AttributesBuilder) this)
+            let builder =
+                (^T: (member Builder : Attributes.AttributesBuilder) this)
+
             let newBuilder = builder.AddScalars(attrs)
-            let result = (^T: (new: Attributes.AttributesBuilder -> ^T) newBuilder)
+
+            let result =
+                (^T: (new : Attributes.AttributesBuilder -> ^T) newBuilder)
+
             result
 
     [<Extension>]
     static member inline AddWidgetCollectionAttribute(this: ^T, attr: WidgetCollectionAttribute) =
-        let builder = (^T : (member Builder: Attributes.AttributesBuilder) this)
+        let builder =
+            (^T: (member Builder : Attributes.AttributesBuilder) this)
+
         let newBuilder = builder.AddWidgetCollection(attr)
-        let result = (^T: (new: Attributes.AttributesBuilder -> ^T) newBuilder)
+
+        let result =
+            (^T: (new : Attributes.AttributesBuilder -> ^T) newBuilder)
+
         result

--- a/src/Fabulous/Runners.fs
+++ b/src/Fabulous/Runners.fs
@@ -25,7 +25,14 @@ module Runners =
 
         member _.Key = key
         member _.Program = program
-        member _.ViewTreeContext = { Dispatch = unbox >> processMsg; CanReuseView = program.CanReuseView }
+
+        member _.ViewTreeContext =
+            {
+                Dispatch = unbox >> processMsg
+                CanReuseView = program.CanReuseView
+                Ancestors = []
+            }
+
         member _.Start(arg) = start arg
         member _.Pause() = ()
         member _.Restart() = ()
@@ -43,7 +50,15 @@ module Runners =
 module ViewAdapters =
     open Runners
 
-    type ViewAdapter<'model>(key: ViewAdapterKey, stateKey: StateKey, view: 'model -> Widget, context: ViewTreeContext, getViewNode: obj -> IViewNode, canReuseView: Widget -> Widget -> bool) as this =
+    type ViewAdapter<'model>
+        (
+            key: ViewAdapterKey,
+            stateKey: StateKey,
+            view: 'model -> Widget,
+            context: ViewTreeContext,
+            getViewNode: obj -> IViewNode,
+            canReuseView: Widget -> Widget -> bool
+        ) as this =
 
         let mutable _widget: Widget = Unchecked.defaultof<Widget>
         let mutable _root = Unchecked.defaultof<obj>
@@ -70,7 +85,7 @@ module ViewAdapters =
 
                 // TODO handle the case when Type of the widget changes
                 Reconciler.update getViewNode canReuseView (ValueSome prevWidget) currentWidget _root
-                
+
 
         member _.Dispose() = _stateSubscription.Dispose()
 
@@ -84,7 +99,14 @@ module ViewAdapters =
         let key = ViewAdapterStore.getNextKey()
 
         let viewAdapter =
-            new ViewAdapter<'model>(key, runner.Key, runner.Program.View, runner.ViewTreeContext, getViewNode, canReuseView)
+            new ViewAdapter<'model>(
+                key,
+                runner.Key,
+                runner.Program.View,
+                runner.ViewTreeContext,
+                getViewNode,
+                canReuseView
+            )
 
         ViewAdapterStore.set key viewAdapter
         viewAdapter

--- a/src/Fabulous/Types.fs
+++ b/src/Fabulous/Types.fs
@@ -1,6 +1,7 @@
 ﻿namespace Fabulous
 
 open System
+open Fabulous
 
 /// Dev notes:
 ///
@@ -22,40 +23,51 @@ type ViewAdapterKey = int
 /// Represents a value for a property of a widget.
 /// Can map to a real property (such as Label.Text) or to a non-existent one.
 /// It will be up to the AttributeDefinition to decide how to apply the value.
-type [<Struct>] ScalarAttribute =
-    { Key: AttributeKey
+[<Struct>]
+type ScalarAttribute =
+    {
+        Key: AttributeKey
 #if DEBUG
-      DebugName: string
+        DebugName: string
 #endif
-      Value: obj }
+        Value: obj
+    }
 
 and [<Struct>] WidgetAttribute =
-    { Key: AttributeKey
+    {
+        Key: AttributeKey
 #if DEBUG
-      DebugName: string
+        DebugName: string
 #endif
-      Value: Widget }
+        Value: Widget
+    }
 
 and [<Struct>] WidgetCollectionAttribute =
-    { Key: AttributeKey
+    {
+        Key: AttributeKey
 #if DEBUG
-      DebugName: string
+        DebugName: string
 #endif
-      Value: Widget[] }
+        Value: Widget []
+    }
 
 /// Represents a virtual UI element such as a Label, a Button, etc.
 and [<Struct>] Widget =
-    { Key: WidgetKey
-      ScalarAttributes: ScalarAttribute[]
-      WidgetAttributes: WidgetAttribute[]
-      WidgetCollectionAttributes: WidgetCollectionAttribute[] }
+    {
+        Key: WidgetKey
+        ScalarAttributes: ScalarAttribute []
+        WidgetAttributes: WidgetAttribute []
+        WidgetCollectionAttributes: WidgetCollectionAttribute []
+    }
 
     member x.GetScalarOrDefault<'T>(key: AttributeKey, defaultValue: 'T) =
-        match x.ScalarAttributes |> Array.tryFind (fun attr -> attr.Key = key) with
+        match x.ScalarAttributes
+              |> Array.tryFind(fun attr -> attr.Key = key) with
         | None -> defaultValue
         | Some attr -> unbox<'T> attr.Value
 
-type [<Struct; RequireQualifiedAccess>] ScalarChange =
+[<Struct; RequireQualifiedAccess>]
+type ScalarChange =
     | Added of added: ScalarAttribute
     | Removed of removed: ScalarAttribute
     | Updated of updated: ScalarAttribute
@@ -65,11 +77,11 @@ and [<Struct; RequireQualifiedAccess>] WidgetChange =
     | Removed of removed: WidgetAttribute
     | Updated of updated: struct (WidgetAttribute * WidgetDiff)
     | ReplacedBy of replacedBy: WidgetAttribute
-    
+
 and [<Struct; RequireQualifiedAccess>] WidgetCollectionChange =
     | Added of added: WidgetCollectionAttribute
     | Removed of removed: WidgetCollectionAttribute
-    | Updated of updated: struct (WidgetCollectionAttribute * WidgetCollectionItemChange[])
+    | Updated of updated: struct (WidgetCollectionAttribute * WidgetCollectionItemChange [])
 
 and [<Struct; RequireQualifiedAccess>] WidgetCollectionItemChange =
     | Insert of widgetInserted: struct (int * Widget)
@@ -78,35 +90,44 @@ and [<Struct; RequireQualifiedAccess>] WidgetCollectionItemChange =
     | Remove of removed: int
 
 and [<Struct>] WidgetDiff =
-    { ScalarChanges: ScalarChange[]
-      WidgetChanges: WidgetChange[]
-      WidgetCollectionChanges: WidgetCollectionChange[] }
+    {
+        ScalarChanges: ScalarChange []
+        WidgetChanges: WidgetChange []
+        WidgetCollectionChanges: WidgetCollectionChange []
+    }
 
 [<Struct; RequireQualifiedAccess>]
 type ScalarAttributeComparison =
     | Identical
     | Different of newData: obj
 
-type [<Struct>] ViewTreeContext =
-    { CanReuseView: Widget -> Widget -> bool
-      Dispatch: obj -> unit }
 
 type Program<'arg, 'model, 'msg> =
-    { Init : 'arg -> 'model * Cmd<'msg>
-      Update : 'msg * 'model -> 'model * Cmd<'msg>
-      View : 'model -> Widget
-      CanReuseView: Widget -> Widget -> bool }
+    {
+        Init: 'arg -> 'model * Cmd<'msg>
+        Update: 'msg * 'model -> 'model * Cmd<'msg>
+        View: 'model -> Widget
+        CanReuseView: Widget -> Widget -> bool
+    }
 
 /// Represents a UI element created from a widget
 type IViewNode =
-    abstract Origin: WidgetKey
-    abstract Context: ViewTreeContext
-    abstract MapMsg: obj -> obj
+    abstract Origin : WidgetKey
+    abstract Context : ViewTreeContext
+    abstract MapMsg : (obj -> obj) voption with get, set
     abstract TryGetHandler<'T> : AttributeKey -> 'T option
     abstract SetHandler<'T> : AttributeKey * 'T voption -> unit
-    abstract ApplyScalarDiff : ScalarChange[] -> unit
-    abstract ApplyWidgetDiff : WidgetChange[] -> unit
-    abstract ApplyWidgetCollectionDiff : WidgetCollectionChange[] -> unit
+    abstract ApplyScalarDiff : ScalarChange [] -> unit
+    abstract ApplyWidgetDiff : WidgetChange [] -> unit
+    abstract ApplyWidgetCollectionDiff : WidgetCollectionChange [] -> unit
+
+and [<Struct>] ViewTreeContext =
+    {
+        CanReuseView: Widget -> Widget -> bool
+        Dispatch: obj -> unit
+        // the last ancestor, e.g. closest to leaf, comes first
+        Ancestors: IViewNode list
+    }
 
 type IRunner =
     interface

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -1,14 +1,14 @@
 ﻿namespace Fabulous
 
-type ViewNode(key, context: ViewTreeContext, mapMsg: obj -> obj, targetRef: System.WeakReference) =
+type ViewNode(key, context: ViewTreeContext, targetRef: System.WeakReference) =
     let mutable _handlers: Map<AttributeKey, obj> = Map.empty
 
     interface IViewNode with
         member _.Origin = key
         member _.Context = context
-        member _.MapMsg(msg) = mapMsg msg
+        member val MapMsg = ValueNone with get,set
 
-        member _.TryGetHandler<'T>(key: AttributeKey): 'T option =
+        member _.TryGetHandler<'T>(key: AttributeKey) : 'T option =
             _handlers
             |> Map.tryFind key
             |> Option.map unbox<'T>
@@ -16,27 +16,38 @@ type ViewNode(key, context: ViewTreeContext, mapMsg: obj -> obj, targetRef: Syst
         member _.SetHandler<'T>(key: AttributeKey, handlerOpt: 'T voption) =
             _handlers <-
                 _handlers
-                |> Map.change key (fun _ -> match handlerOpt with ValueNone -> None | ValueSome h -> Some (box h))
+                |> Map.change
+                    key
+                    (fun _ ->
+                        match handlerOpt with
+                        | ValueNone -> None
+                        | ValueSome h -> Some(box h))
 
-        member _.ApplyScalarDiff(diffs) =
+        member x.ApplyScalarDiff(diffs) =
             if not targetRef.IsAlive then
                 ()
             else
                 for diff in diffs do
                     match diff with
                     | ScalarChange.Added added ->
-                        let definition = AttributeDefinitionStore.get added.Key :?> IScalarAttributeDefinition
-                        definition.UpdateTarget(ValueSome added.Value, targetRef.Target)
+                        let definition =
+                            AttributeDefinitionStore.get added.Key :?> IScalarAttributeDefinition
+
+                        definition.UpdateTarget(ValueSome added.Value, x, targetRef.Target)
 
                     | ScalarChange.Removed removed ->
-                        let definition = AttributeDefinitionStore.get removed.Key :?> IScalarAttributeDefinition
-                        definition.UpdateTarget(ValueNone, targetRef.Target)
+                        let definition =
+                            AttributeDefinitionStore.get removed.Key :?> IScalarAttributeDefinition
+
+                        definition.UpdateTarget(ValueNone, x, targetRef.Target)
 
                     | ScalarChange.Updated newAttr ->
-                        let definition = AttributeDefinitionStore.get newAttr.Key :?> IScalarAttributeDefinition
-                        definition.UpdateTarget(ValueSome newAttr.Value, targetRef.Target)
+                        let definition =
+                            AttributeDefinitionStore.get newAttr.Key :?> IScalarAttributeDefinition
 
-        member _.ApplyWidgetDiff(diffs) =
+                        definition.UpdateTarget(ValueSome newAttr.Value, x, targetRef.Target)
+
+        member x.ApplyWidgetDiff(diffs) =
             if not targetRef.IsAlive then
                 ()
             else
@@ -44,31 +55,43 @@ type ViewNode(key, context: ViewTreeContext, mapMsg: obj -> obj, targetRef: Syst
                     match diff with
                     | WidgetChange.Added newWidget
                     | WidgetChange.ReplacedBy newWidget ->
-                        let definition = AttributeDefinitionStore.get newWidget.Key :?> WidgetAttributeDefinition
-                        definition.UpdateTarget(ValueSome newWidget.Value, targetRef.Target)
+                        let definition =
+                            AttributeDefinitionStore.get newWidget.Key :?> WidgetAttributeDefinition
+
+                        definition.UpdateTarget(ValueSome newWidget.Value, x, targetRef.Target)
 
                     | WidgetChange.Removed removed ->
-                        let definition = AttributeDefinitionStore.get removed.Key :?> WidgetAttributeDefinition
-                        definition.UpdateTarget(ValueNone, targetRef.Target)
+                        let definition =
+                            AttributeDefinitionStore.get removed.Key :?> WidgetAttributeDefinition
+
+                        definition.UpdateTarget(ValueNone, x, targetRef.Target)
 
                     | WidgetChange.Updated struct (newAttr, diffs) ->
-                        let definition = AttributeDefinitionStore.get newAttr.Key :?> WidgetAttributeDefinition
+                        let definition =
+                            AttributeDefinitionStore.get newAttr.Key :?> WidgetAttributeDefinition
+
                         definition.ApplyDiff(diffs, targetRef.Target)
 
-        member _.ApplyWidgetCollectionDiff(diffs) =
+        member x.ApplyWidgetCollectionDiff(diffs) =
             if not targetRef.IsAlive then
                 ()
             else
                 for diff in diffs do
                     match diff with
                     | WidgetCollectionChange.Added added ->
-                        let definition = AttributeDefinitionStore.get added.Key :?> WidgetCollectionAttributeDefinition
-                        definition.UpdateTarget(ValueSome added.Value, targetRef.Target)
-                        
+                        let definition =
+                            AttributeDefinitionStore.get added.Key :?> WidgetCollectionAttributeDefinition
+
+                        definition.UpdateTarget(ValueSome added.Value, x, targetRef.Target)
+
                     | WidgetCollectionChange.Removed removed ->
-                        let definition = AttributeDefinitionStore.get removed.Key :?> WidgetCollectionAttributeDefinition
-                        definition.UpdateTarget(ValueNone, targetRef.Target)
+                        let definition =
+                            AttributeDefinitionStore.get removed.Key :?> WidgetCollectionAttributeDefinition
+
+                        definition.UpdateTarget(ValueNone, x, targetRef.Target)
 
                     | WidgetCollectionChange.Updated struct (newAttr, diffs) ->
-                        let definition = AttributeDefinitionStore.get newAttr.Key :?> WidgetCollectionAttributeDefinition
+                        let definition =
+                            AttributeDefinitionStore.get newAttr.Key :?> WidgetCollectionAttributeDefinition
+
                         definition.ApplyDiff(diffs, targetRef.Target)


### PR DESCRIPTION
fixes https://github.com/TimLariviere/Fabulous-new/issues/11

from our conversation on Discord
---

> 
> @TimLariviere I'm trying to make a nicer MapMsg approach and I noticed an interesting thing
> [4:39 PM]
> we calculate the diff recursively and all at once
> [4:40 PM]
> e.g. we calculate a potentially large data sctructure that represents the diff for the entire tree
> [4:42 PM]
> I haven't reconciled all the pros and cons of it but there are a couple of thoughts that came to my mind:
> 1. Allocating a big diff can represent a perf issue. Not sure if it is relevant or going to be just fine in practice.
> 2. ViewNode doesn't have a reference to a widget it represents currently
> [4:43 PM]
> so 2. is relevant for me in the context of MapMsg work: there is no easy way to access scalar attributes for a view node at the moment of dispatch
> [4:45 PM]
> I think I will add a temprorary hack of adding current scalar attribute to a view node, but I'm curious if there is a more elegant solution
> [4:47 PM]
> like so
> abstract ApplyScalarDiff : struct (ScalarChange[] * ScalarAttribute[]) -> unit
>  
> Simon Korzunov — Today at 11:28 PM
> Upd: I was able not to do that
> [11:29 PM]
> instead I just uses the attribute update function to set IViewNode.MapMsg
> [11:30 PM]
> so with that and adding Ancestors to ViewTreeContext I was able to achieve the goal
> [11:31 PM]
> now when we dispatch a message it goes through the parent chain and maps the message along the way
> [11:31 PM]
> What I haven't figured out yet is how to do it the way you wanted with typesafe children (like ITabbedPage)
> [11:34 PM]
> What I would love to do but haven't figured out yet is this:
> 
>  [<Extension>]
>     static member inline AddScalar_(this: ^T :> IWidgetBuilder, attr: ScalarAttribute) =
>         let newAttribs = ...
>         let result =
>             (^T: (new : ScalarAttribute [] * WidgetAttribute [] * WidgetCollectionAttribute [] -> ^T) (...)
> 
>         result
> 
> 
> but  (^T: (new : ScalarAttribute [] * WidgetAttribute [] * WidgetCollectionAttribute [] -> ^T) (...) call would change the type of the msg to a new one
> [11:35 PM]
> technically it should be possible to achieve because the actual message type is phantom, but my typefoo is not strong enough
> [11:35 PM]
> will have a PR in a sec
> [11:37 PM]
> https://github.com/TimLariviere/Fabulous-new/tree/simon/rework-map-msg
> 
> [11:38 PM]
> @TimLariviere I haven't checked if this works, could you verify on Contacts? It should all work e2e
> If it does I suggest to merge it, if you onboard with changes it would be awesome if you do so. Let me create a PR for that
> 
