### PR TITLE
Implementation of View.memo (dependsOn in Fab v1)

### DIFF
--- a/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
@@ -39,14 +39,17 @@ module Configuration =
         | StepChanged n -> { model with Step = int (n + 0.5) }
         | TimerToggled on -> { model with TimerOn = on }
         
+    let timerView timerOn =
+        HorizontalStackLayout() {
+            Label($"Timer - {System.DateTime.Now}")
+
+            Switch(timerOn, TimerToggled)
+                .automationId("TimerSwitch")
+        }
+        
     let view model =
         VerticalStackLayout() {
-            HorizontalStackLayout() {
-                Label("Timer")
-
-                Switch(model.TimerOn, TimerToggled)
-                    .automationId("TimerSwitch")
-            }
+            View.memo model.TimerOn timerView
             
             Slider(min = 0., max = 10., value = float model.Step, onValueChanged = StepChanged)
                 .automationId("StepSlider")

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -521,14 +521,14 @@ module MemoTests =
                 | Label1 ->
                     View.memo
                         model
-                        (fun i ->
+                        (fun _ ->
                             Label("one")
                                 .textColor("blue")
                                 .automationId("label"))
                 | Label2 ->
                     View.memo
-                        model
-                        (fun i ->
+                        (string model)
+                        (fun _ ->
                             Label("two")
                                 .textColor("blue")
                                 .automationId("label"))

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -560,7 +560,7 @@ module MemoTests =
                 [
                     TextSet "one"
                     ColorSet "blue"
-                    TextSet "one"
+                    TextSet "two"
                 ],
                 label.changeList
             )

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -387,66 +387,180 @@ module MapViewTests =
 
 
 module MemoTests =
-    type Model =
-        {
-            notMemoized: string
-            memoTrigger: int
-        }
-
-    type Msg =
-        | SetNotMemoPart of string
-        | SetMemoPart of int
-
-    let update msg model =
-        match msg with
-        | SetMemoPart i -> { model with memoTrigger = i }
-        | SetNotMemoPart s -> { model with notMemoized = s }
-
-    let mutable renderCount = 0
-
-    let view model =
-        Stack() {
-            Label<Msg>(model.notMemoized)
-                .automationId("not_memo")
-
-            View.memo
-                model.memoTrigger
-                (fun i ->
-                    renderCount <- renderCount + 1
-                    Label(string i).automationId("memo"))
-        }
-
-    [<Test>]
-    let MemoizedCorrectly () =
-
-        let init () =
+    module BasicCase =
+        type Model =
             {
-                notMemoized = "initial"
-                memoTrigger = 0
+                notMemoized: string
+                memoTrigger: int
             }
 
-        let program =
-            StatefulWidget.mkSimpleView init update view
+        type Msg =
+            | SetNotMemoPart of string
+            | SetMemoPart of int
 
-        let instance = Run.Instance program
-        let tree = (instance.Start())
+        let update msg model =
+            match msg with
+            | SetMemoPart i -> { model with memoTrigger = i }
+            | SetNotMemoPart s -> { model with notMemoized = s }
 
-        // executed just once to construct the tree
-        Assert.AreEqual(1, renderCount)
+        let mutable renderCount = 0
 
-        let notMemoLabel = find<TestLabel> tree "not_memo" :> IText
-        let memoLabel = find<TestLabel> tree "memo" :> IText
+        let view model =
+            Stack() {
+                Label<Msg>(model.notMemoized)
+                    .automationId("not_memo")
 
-        Assert.AreEqual("0", memoLabel.Text)
+                View.memo
+                    model.memoTrigger
+                    (fun i ->
+                        renderCount <- renderCount + 1
+                        Label(string i).automationId("memo"))
+            }
 
-        instance.ProcessMessage(SetNotMemoPart "hey")
-        Assert.AreEqual("hey", notMemoLabel.Text)
+        [<Test>]
+        let Test () =
 
-        // hasn't been rerendered
-        Assert.AreEqual(1, renderCount)
+            let init () =
+                {
+                    notMemoized = "initial"
+                    memoTrigger = 0
+                }
 
-        instance.ProcessMessage(SetMemoPart 99)
+            let program =
+                StatefulWidget.mkSimpleView init update view
 
-        // rerendered because of memo key changed
-        Assert.AreEqual(2, renderCount)
-        Assert.AreEqual("99", memoLabel.Text)
+            let instance = Run.Instance program
+            let tree = (instance.Start())
+
+            // executed just once to construct the tree
+            Assert.AreEqual(1, renderCount)
+
+            let notMemoLabel = find<TestLabel> tree "not_memo" :> IText
+            let memoLabel = find<TestLabel> tree "memo" :> IText
+
+            Assert.AreEqual("0", memoLabel.Text)
+
+            instance.ProcessMessage(SetNotMemoPart "hey")
+            Assert.AreEqual("hey", notMemoLabel.Text)
+
+            // hasn't been rerendered
+            Assert.AreEqual(1, renderCount)
+
+            instance.ProcessMessage(SetMemoPart 99)
+
+            // rerendered because of memo key changed
+            Assert.AreEqual(2, renderCount)
+            Assert.AreEqual("99", memoLabel.Text)
+
+    module MemoizedWidgetTypeChange =
+        type Model =
+            | Btn
+            | Lbl
+
+        type Msg = Change
+
+        let update msg model =
+            match msg with
+            | Change ->
+                match model with
+                | Btn -> Lbl
+                | Lbl -> Btn
+
+        let view model =
+            (Stack() {
+                match model with
+                | Btn -> View.memo model (fun i -> Button(string i, Change).automationId("btn"))
+                | Lbl -> View.memo model (fun i -> Label(string i).automationId("label"))
+             })
+                .automationId("stack")
+
+        [<Test>]
+        let Test () =
+
+            let init () = Btn
+
+            let program =
+                StatefulWidget.mkSimpleView init update view
+
+            let instance = Run.Instance program
+            let tree = (instance.Start())
+
+            let stack =
+                find<TestStack> tree "stack" :> IContainer
+
+            Assert.AreEqual(1, stack.Children.Count)
+
+
+            let btn = find<TestButton> tree "btn"
+            btn.Press()
+
+            // still one child
+            Assert.AreEqual(1, stack.Children.Count)
+
+            // but it is label now
+            let label = find<TestLabel> tree "label" :> IText
+            Assert.AreEqual(string Lbl, label.Text)
+
+    module ViewNodeInstanceCanBeReused =
+        type Model =
+            | Label1
+            | Label2
+
+        type Msg = Change
+
+        let update msg model =
+            match msg with
+            | Change ->
+                match model with
+                | Label1 -> Label2
+                | Label2 -> Label1
+
+        let view model =
+            Stack() {
+                match model with
+                | Label1 ->
+                    View.memo
+                        model
+                        (fun i ->
+                            Label("one")
+                                .textColor("blue")
+                                .automationId("label"))
+                | Label2 ->
+                    View.memo
+                        model
+                        (fun i ->
+                            Label("two")
+                                .textColor("blue")
+                                .automationId("label"))
+            }
+
+        [<Test>]
+        let Test () =
+
+            let init () = Label1
+
+            let program =
+                StatefulWidget.mkSimpleView init update view
+
+            let instance = Run.Instance program
+            let tree = (instance.Start())
+
+            let label = find<TestLabel> tree "label"
+            Assert.AreEqual([ TextSet "one"; ColorSet "blue" ], label.changeList)
+
+            instance.ProcessMessage(Change)
+
+            let labelAgain = find<TestLabel> tree "label"
+
+            // same instance
+            Assert.AreSame(label, labelAgain)
+
+            // just changes text but kept the same color
+            Assert.AreEqual(
+                [
+                    TextSet "one"
+                    ColorSet "blue"
+                    TextSet "one"
+                ],
+                label.changeList
+            )

--- a/src/Fabulous.Tests/TestUI.Platform.fs
+++ b/src/Fabulous.Tests/TestUI.Platform.fs
@@ -2,6 +2,7 @@ module Tests.Platform
 
 open System.Collections.Generic
 
+
 type TestViewElement() =
     member val AutomationId: string = "" with get, set
     member val PropertyBag = Dictionary<string, obj>()
@@ -19,12 +20,31 @@ type IButton =
     abstract AddPressListener : ButtonHandler -> int
     abstract RemovePressListener : int -> unit
 
+type LabelChangeList =
+    | TextSet of string
+    | ColorSet of string
+
+
 type TestLabel() =
     inherit TestViewElement()
 
+    let mutable text = ""
+    let mutable textColor = ""
+
+    member val changeList = [] with get, set
+
     interface IText with
-        member val Text = "" with get, set
-        member val TextColor = "" with get, set
+        member x.Text
+            with get () = text
+            and set (value) =
+                x.changeList <- List.append x.changeList [ TextSet value ]
+                text <- value
+
+        member x.TextColor
+            with get () = textColor
+            and set (value) =
+                x.changeList <- List.append x.changeList [ ColorSet value ]
+                textColor <- value
 
 type TestStack() =
     inherit TestViewElement()

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -173,7 +173,7 @@ module Run =
 
         member private x.viewContext: ViewTreeContext =
             {
-                CanReuseView = fun a b -> a.Key = b.Key
+                CanReuseView = Helpers.canReuseView
                 Dispatch = fun msg -> unbox<'msg> msg |> x.ProcessMessage
                 GetViewNode = ViewNode.getViewNode
             }

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -173,7 +173,7 @@ module Run =
 
         member private x.viewContext: ViewTreeContext =
             {
-                CanReuseView = Helpers.canReuseView
+                CanReuseView = ViewHelpers.canReuseView
                 Dispatch = fun msg -> unbox<'msg> msg |> x.ProcessMessage
                 GetViewNode = ViewNode.getViewNode
             }

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -122,13 +122,20 @@ type View private () =
 [<Extension>]
 type CollectionBuilderExtensions =
     [<Extension>]
-    static member Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
+    static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
         (
             _: CollectionBuilder<'msg, 'marker, IMarker>,
             x: WidgetBuilder<'msg, 'itemMarker>
         ) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
 
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
+        (
+            _: CollectionBuilder<'msg, 'marker, IMarker>,
+            x: WidgetBuilder<'msg, Memo.Memoized<'itemMarker>>
+        ) : Content<'msg> =
+        { Widgets = [ x.Compile() ] }
 
     [<Extension>]
     static member inline YieldFrom<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -44,7 +44,7 @@ module Widgets =
                             widget
                             viewNode
 
-                        box view
+                        struct (viewNode, box view)
             }
 
         WidgetDefinitionStore.set key definition
@@ -207,7 +207,7 @@ module Run =
             let widget = program.View(model).Compile()
             let widgetDef = WidgetDefinitionStore.get widget.Key
 
-            let view =
+            let struct (_node, view) =
                 widgetDef.CreateView(widget, x.viewContext, ValueNone)
 
             state <- Some(model, view, widget)

--- a/src/Fabulous.XamarinForms/Program.fs
+++ b/src/Fabulous.XamarinForms/Program.fs
@@ -7,7 +7,7 @@ module Program =
         { Init = init
           Update = (fun (msg, model) -> update msg model)
           View = fun model -> (view model).Compile()
-          CanReuseView = Helpers.canReuseView }
+          CanReuseView = ViewHelpers.canReuseView }
 
     let statelessApplication (view: unit -> WidgetBuilder<unit, #IApplication>) =
         define

--- a/src/Fabulous.XamarinForms/ViewUpdaters.fs
+++ b/src/Fabulous.XamarinForms/ViewUpdaters.fs
@@ -94,7 +94,7 @@ module ViewUpdaters =
                         navigationPage.PushAsync(temp.Pop(), false) |> ignore
                         
             | WidgetCollectionItemChange.Update (index, diff) ->
-                let childNode = node.GetViewNodeForChild(pages[index])
+                let childNode = node.TreeContext.GetViewNode(pages[index])
                 if diff.ScalarChanges.Length > 0 then childNode.ApplyScalarDiffs(diff.ScalarChanges)
                 if diff.WidgetChanges.Length > 0 then childNode.ApplyWidgetDiffs(diff.WidgetChanges)
                 if diff.WidgetCollectionChanges.Length > 0 then childNode.ApplyWidgetCollectionDiffs(diff.WidgetCollectionChanges)

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -59,6 +59,20 @@ type CollectionBuilderExtensions =
     static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>(_: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
         
+        
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPage>(_: CollectionBuilder<'msg, 'marker, IPage>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = [ x.Compile() ] }
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IView>(_: CollectionBuilder<'msg, 'marker, IView>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = [ x.Compile() ] }
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>(_: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = [ x.Compile() ] }
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>(_: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = [ x.Compile() ] }
+        
 module ViewHelpers =
     let inline compileSeq (items: seq<WidgetBuilder<'msg, #IMarker>>) =
         items

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -5,15 +5,33 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Fabulous.XamarinForms
 
-type IMarker = interface end
-type IApplication = inherit IMarker
-type IPage = inherit IMarker
-type IView = inherit IMarker
-type ICell = inherit IMarker
-type IMenuItem = inherit IMarker
-type IGestureRecognizer = inherit IMarker
-type ILayout = inherit IView
-type IToolbarItem = inherit IMenuItem
+type IMarker =
+    interface
+    end
+
+type IApplication =
+    inherit IMarker
+
+type IPage =
+    inherit IMarker
+
+type IView =
+    inherit IMarker
+
+type ICell =
+    inherit IMarker
+
+type IMenuItem =
+    inherit IMarker
+
+type IGestureRecognizer =
+    inherit IMarker
+
+type ILayout =
+    inherit IView
+
+type IToolbarItem =
+    inherit IMenuItem
 
 module Widgets =
     let register<'T when 'T :> Xamarin.Forms.BindableObject and 'T: (new : unit -> 'T)> () =
@@ -30,55 +48,88 @@ module Widgets =
 
                         let view = new 'T()
                         let weakReference = WeakReference(view)
-                        
+
                         let node =
                             ViewNode(parentNode, treeContext, weakReference)
 
                         view.SetValue(ViewNode.ViewNodeProperty, node)
 
                         Reconciler.update treeContext.CanReuseView ValueNone widget node
-
-                        box view
+                        struct (node, box view)
             }
 
         WidgetDefinitionStore.set key definition
         key
-    
+
 [<Extension>]
 type CollectionBuilderExtensions =
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPage>(_: CollectionBuilder<'msg, 'marker, IPage>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPage>
+        (
+            _: CollectionBuilder<'msg, 'marker, IPage>,
+            x: WidgetBuilder<'msg, 'itemType>
+        ) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
+
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IView>(_: CollectionBuilder<'msg, 'marker, IView>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IView>
+        (
+            _: CollectionBuilder<'msg, 'marker, IView>,
+            x: WidgetBuilder<'msg, 'itemType>
+        ) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
+
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>(_: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>
+        (
+            _: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>,
+            x: WidgetBuilder<'msg, 'itemType>
+        ) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
+
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>(_: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>
+        (
+            _: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>,
+            x: WidgetBuilder<'msg, 'itemType>
+        ) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
-        
+
 module ViewHelpers =
     let inline compileSeq (items: seq<WidgetBuilder<'msg, #IMarker>>) =
         items
-        |> Seq.map (fun item -> item.Compile())
+        |> Seq.map(fun item -> item.Compile())
         |> Seq.toArray
-        
-    let inline buildScalars<'msg, 'marker> (key: WidgetKey) (attrs: ScalarAttribute[]) =
+
+    let inline buildScalars<'msg, 'marker> (key: WidgetKey) (attrs: ScalarAttribute []) =
         WidgetBuilder<'msg, 'marker>(key, struct (attrs, [||], [||]))
-        
-    let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute[]) =
+
+    let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute []) =
         WidgetBuilder<'msg, 'marker>(key, struct ([||], attrs, [||]))
-        
-    let inline build<'msg, 'marker> (key: WidgetKey) (scalars: ScalarAttribute[]) (widgets: WidgetAttribute[]) (widgetColls: WidgetCollectionAttribute[]) =
+
+    let inline build<'msg, 'marker>
+        (key: WidgetKey)
+        (scalars: ScalarAttribute [])
+        (widgets: WidgetAttribute [])
+        (widgetColls: WidgetCollectionAttribute [])
+        =
         WidgetBuilder<'msg, 'marker>(key, struct (scalars, widgets, widgetColls))
-        
-    let inline buildCollectionNoScalar<'msg, 'marker, 'item> (key: WidgetKey) (collectionAttributeDefinition: WidgetCollectionAttributeDefinition) =
+
+    let inline buildCollectionNoScalar<'msg, 'marker, 'item>
+        (key: WidgetKey)
+        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
+        =
         CollectionBuilder<'msg, 'marker, 'item>(key, ValueNone, collectionAttributeDefinition)
-        
-    let inline buildCollection<'msg, 'marker, 'item> (key: WidgetKey) (collectionAttributeDefinition: WidgetCollectionAttributeDefinition) (scalars: ScalarAttribute[]) =
+
+    let inline buildCollection<'msg, 'marker, 'item>
+        (key: WidgetKey)
+        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
+        (scalars: ScalarAttribute [])
+        =
         CollectionBuilder<'msg, 'marker, 'item>(key, ValueSome scalars, collectionAttributeDefinition)
-        
-    let inline buildAttributeCollection<'msg, 'marker, 'item> (collectionAttributeDefinition: WidgetCollectionAttributeDefinition) (widget: WidgetBuilder<'msg, 'marker>) =
+
+    let inline buildAttributeCollection<'msg, 'marker, 'item>
+        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
+        (widget: WidgetBuilder<'msg, 'marker>)
+        =
         AttributeCollectionBuilder<'msg, 'marker, 'item>(widget, collectionAttributeDefinition)

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -5,33 +5,15 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Fabulous.XamarinForms
 
-type IMarker =
-    interface
-    end
-
-type IApplication =
-    inherit IMarker
-
-type IPage =
-    inherit IMarker
-
-type IView =
-    inherit IMarker
-
-type ICell =
-    inherit IMarker
-
-type IMenuItem =
-    inherit IMarker
-
-type IGestureRecognizer =
-    inherit IMarker
-
-type ILayout =
-    inherit IView
-
-type IToolbarItem =
-    inherit IMenuItem
+type IMarker = interface end
+type IApplication = inherit IMarker
+type IPage = inherit IMarker
+type IView = inherit IMarker
+type ICell = inherit IMarker
+type IMenuItem = inherit IMarker
+type IGestureRecognizer = inherit IMarker
+type ILayout = inherit IView
+type IToolbarItem = inherit IMenuItem
 
 module Widgets =
     let register<'T when 'T :> Xamarin.Forms.BindableObject and 'T: (new : unit -> 'T)> () =
@@ -48,88 +30,55 @@ module Widgets =
 
                         let view = new 'T()
                         let weakReference = WeakReference(view)
-
+                        
                         let node =
                             ViewNode(parentNode, treeContext, weakReference)
 
                         view.SetValue(ViewNode.ViewNodeProperty, node)
 
                         Reconciler.update treeContext.CanReuseView ValueNone widget node
+
                         struct (node, box view)
             }
 
         WidgetDefinitionStore.set key definition
         key
-
+    
 [<Extension>]
 type CollectionBuilderExtensions =
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPage>
-        (
-            _: CollectionBuilder<'msg, 'marker, IPage>,
-            x: WidgetBuilder<'msg, 'itemType>
-        ) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPage>(_: CollectionBuilder<'msg, 'marker, IPage>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
-
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IView>
-        (
-            _: CollectionBuilder<'msg, 'marker, IView>,
-            x: WidgetBuilder<'msg, 'itemType>
-        ) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IView>(_: CollectionBuilder<'msg, 'marker, IView>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
-
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>
-        (
-            _: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>,
-            x: WidgetBuilder<'msg, 'itemType>
-        ) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>(_: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
-
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>
-        (
-            _: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>,
-            x: WidgetBuilder<'msg, 'itemType>
-        ) : Content<'msg> =
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>(_: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
         { Widgets = [ x.Compile() ] }
-
+        
 module ViewHelpers =
     let inline compileSeq (items: seq<WidgetBuilder<'msg, #IMarker>>) =
         items
-        |> Seq.map(fun item -> item.Compile())
+        |> Seq.map (fun item -> item.Compile())
         |> Seq.toArray
-
-    let inline buildScalars<'msg, 'marker> (key: WidgetKey) (attrs: ScalarAttribute []) =
+        
+    let inline buildScalars<'msg, 'marker> (key: WidgetKey) (attrs: ScalarAttribute[]) =
         WidgetBuilder<'msg, 'marker>(key, struct (attrs, [||], [||]))
-
-    let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute []) =
+        
+    let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute[]) =
         WidgetBuilder<'msg, 'marker>(key, struct ([||], attrs, [||]))
-
-    let inline build<'msg, 'marker>
-        (key: WidgetKey)
-        (scalars: ScalarAttribute [])
-        (widgets: WidgetAttribute [])
-        (widgetColls: WidgetCollectionAttribute [])
-        =
+        
+    let inline build<'msg, 'marker> (key: WidgetKey) (scalars: ScalarAttribute[]) (widgets: WidgetAttribute[]) (widgetColls: WidgetCollectionAttribute[]) =
         WidgetBuilder<'msg, 'marker>(key, struct (scalars, widgets, widgetColls))
-
-    let inline buildCollectionNoScalar<'msg, 'marker, 'item>
-        (key: WidgetKey)
-        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
-        =
+        
+    let inline buildCollectionNoScalar<'msg, 'marker, 'item> (key: WidgetKey) (collectionAttributeDefinition: WidgetCollectionAttributeDefinition) =
         CollectionBuilder<'msg, 'marker, 'item>(key, ValueNone, collectionAttributeDefinition)
-
-    let inline buildCollection<'msg, 'marker, 'item>
-        (key: WidgetKey)
-        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
-        (scalars: ScalarAttribute [])
-        =
+        
+    let inline buildCollection<'msg, 'marker, 'item> (key: WidgetKey) (collectionAttributeDefinition: WidgetCollectionAttributeDefinition) (scalars: ScalarAttribute[]) =
         CollectionBuilder<'msg, 'marker, 'item>(key, ValueSome scalars, collectionAttributeDefinition)
-
-    let inline buildAttributeCollection<'msg, 'marker, 'item>
-        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
-        (widget: WidgetBuilder<'msg, 'marker>)
-        =
+        
+    let inline buildAttributeCollection<'msg, 'marker, 'item> (collectionAttributeDefinition: WidgetCollectionAttributeDefinition) (widget: WidgetBuilder<'msg, 'marker>) =
         AttributeCollectionBuilder<'msg, 'marker, 'item>(widget, collectionAttributeDefinition)

--- a/src/Fabulous/AttributeDefinitions.fs
+++ b/src/Fabulous/AttributeDefinitions.fs
@@ -10,7 +10,7 @@ type IAttributeDefinition =
 [<Struct; RequireQualifiedAccess>]
 type ScalarAttributeComparison =
     | Identical
-    | Different of newData: obj
+    | Different
 
 type IScalarAttributeDefinition =
     inherit IAttributeDefinition

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -15,13 +15,13 @@ module Helpers =
         view
 
 module ScalarAttributeComparers =
-    let noCompare (_, b) = ScalarAttributeComparison.Different b
+    let noCompare (_, _) = ScalarAttributeComparison.Different
 
     let equalityCompare (a, b) =
         if a = b then
             ScalarAttributeComparison.Identical
         else
-            ScalarAttributeComparison.Different b
+            ScalarAttributeComparison.Different
 
 module Attributes =
     /// Define a custom attribute storing any value

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -20,7 +20,10 @@ module Helpers =
     let inline createViewForWidget (parent: IViewNode) (widget: Widget) =
         let widgetDefinition = WidgetDefinitionStore.get widget.Key
 
-        widgetDefinition.CreateView(widget, parent.TreeContext, ValueSome parent)
+        let struct (_node, view) =
+            widgetDefinition.CreateView(widget, parent.TreeContext, ValueSome parent)
+
+        view
 
 module ScalarAttributeComparers =
     let noCompare (_, b) = ScalarAttributeComparison.Different b

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -126,7 +126,7 @@ module Attributes =
 
                 | WidgetCollectionItemChange.Update (index, widgetDiff) ->
                     let childNode =
-                        node.GetViewNodeForChild(targetColl.[index])
+                        node.TreeContext.GetViewNode(targetColl.[index])
 
                     if widgetDiff.ScalarChanges.Length > 0 then
                         childNode.ApplyScalarDiffs(widgetDiff.ScalarChanges)

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -4,17 +4,6 @@ open System
 open Fabulous
 
 module Helpers =
-    let canReuseView (prevWidget: Widget) (currWidget: Widget) =
-        let prevKey = prevWidget.Key
-
-        if not(prevKey = currWidget.Key) then
-            false
-        else if (prevKey = Memo.MemoWidgetKey) then
-            Memo.canReuseMemoizedViewNode prevWidget currWidget
-        else
-            true
-
-
     let canReuse<'T when 'T: equality> (prev: 'T) (curr: 'T) = prev = curr
 
     let inline createViewForWidget (parent: IViewNode) (widget: Widget) =

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -4,7 +4,16 @@ open System
 open Fabulous
 
 module Helpers =
-    let canReuseView (prevWidget: Widget) (currWidget: Widget) = prevWidget.Key = currWidget.Key
+    let canReuseView (prevWidget: Widget) (currWidget: Widget) =
+        let prevKey = prevWidget.Key
+
+        if not(prevKey = currWidget.Key) then
+            false
+        else if (prevKey = Memo.MemoWidgetKey) then
+            Memo.canReuseMemoizedViewNode prevWidget currWidget
+        else
+            true
+
 
     let canReuse<'T when 'T: equality> (prev: 'T) (curr: 'T) = prev = curr
 
@@ -66,8 +75,8 @@ module Attributes =
     /// Define a custom attribute storing a widget collection
     let defineWidgetCollectionWithConverter
         name
-        (applyDiff: WidgetCollectionItemChange[] * IViewNode -> unit)
-        (updateNode: Widget[] voption * IViewNode -> unit)
+        (applyDiff: WidgetCollectionItemChange [] * IViewNode -> unit)
+        (updateNode: Widget [] voption * IViewNode -> unit)
         =
         let key = AttributeDefinitionStore.getNextKey()
 
@@ -83,10 +92,10 @@ module Attributes =
         definition
 
     /// Define an attribute storing a Widget for a CLR property
-    let defineWidget<'T when 'T : null> (name: string) (get: obj -> IViewNode) (set: obj -> 'T -> unit) =
+    let defineWidget<'T when 'T: null> (name: string) (get: obj -> IViewNode) (set: obj -> 'T -> unit) =
         let applyDiff (diff: WidgetDiff, node: IViewNode) =
             let childNode = get node.Target
-            
+
             if diff.ScalarChanges.Length > 0 then
                 childNode.ApplyScalarDiffs(diff.ScalarChanges)
 
@@ -100,16 +109,15 @@ module Attributes =
             match newValueOpt with
             | ValueNone -> set node.Target null
             | ValueSome widget ->
-                let view = Helpers.createViewForWidget node widget |> unbox
+                let view =
+                    Helpers.createViewForWidget node widget |> unbox
+
                 set node.Target view
 
         defineWidgetWithConverter name applyDiff updateNode
 
     /// Define an attribute storing a collection of Widget
-    let defineWidgetCollection<'itemType>
-        name
-        (getCollection: obj -> System.Collections.Generic.IList<'itemType>)
-        =
+    let defineWidgetCollection<'itemType> name (getCollection: obj -> System.Collections.Generic.IList<'itemType>) =
         let applyDiff (diffs: WidgetCollectionItemChange [], node: IViewNode) =
             let targetColl = getCollection node.Target
 
@@ -125,8 +133,9 @@ module Attributes =
                     targetColl.Insert(index, unbox view)
 
                 | WidgetCollectionItemChange.Update (index, widgetDiff) ->
-                    let childNode = node.GetViewNodeForChild(targetColl[index])
-                    
+                    let childNode =
+                        node.GetViewNodeForChild(targetColl.[index])
+
                     if widgetDiff.ScalarChanges.Length > 0 then
                         childNode.ApplyScalarDiffs(widgetDiff.ScalarChanges)
 
@@ -136,9 +145,9 @@ module Attributes =
                     if widgetDiff.WidgetCollectionChanges.Length > 0 then
                         childNode.ApplyWidgetCollectionDiffs(widgetDiff.WidgetCollectionChanges)
 
-                | WidgetCollectionItemChange.Replace (index, widget) ->                      
+                | WidgetCollectionItemChange.Replace (index, widget) ->
                     let view = Helpers.createViewForWidget node widget
-                    targetColl[index] <- unbox view
+                    targetColl.[index] <- unbox view
 
                 | _ -> ()
 
@@ -160,14 +169,16 @@ module Attributes =
 
     let dispatchMsgOnViewNode (node: IViewNode) msg =
         let mutable parentOpt = node.Parent
+
         let mutable mapMsg =
             match node.MapMsg with
             | ValueNone -> id
-            | ValueSome fn -> fn            
+            | ValueSome fn -> fn
 
         while parentOpt.IsSome do
             let parent = parentOpt.Value
             parentOpt <- parent.Parent
+
             mapMsg <-
                 match parent.MapMsg with
                 | ValueNone -> mapMsg
@@ -188,7 +199,7 @@ module Attributes =
                 UpdateNode =
                     fun (newValueOpt, node) ->
                         let event = getEvent node.Target
-                        
+
                         match node.TryGetHandler(key) with
                         | ValueNone -> ()
                         | ValueSome handler -> event.RemoveHandler handler

--- a/src/Fabulous/Core.fs
+++ b/src/Fabulous/Core.fs
@@ -1,6 +1,5 @@
 ﻿namespace Fabulous
 
-open System.Collections.Generic
 
 /// Dev notes:
 ///
@@ -107,10 +106,11 @@ and IViewNode =
     abstract member TreeContext : ViewTreeContext
     abstract member MapMsg : (obj -> obj) voption with get, set
 
-    // whatever we need to attach to ViewNode in Core
-    // TODO if it is for internal use only it is possible that we should strongly type
-    // values we can expect in here
-    abstract member PropertyBag : Dictionary<int, obj>
+    // note that Widget is struct type, thus we have boxing via option
+    // we don't have MemoizedWidget set for 99.9% of the cases
+    // thus makes sense to have overhead of boxing
+    // in order to save space
+    abstract member MemoizedWidget : Widget option with get, set
     abstract member GetViewNodeForChild : obj -> IViewNode
     abstract member TryGetHandler<'T> : AttributeKey -> 'T voption
     abstract member SetHandler<'T> : AttributeKey * 'T voption -> unit

--- a/src/Fabulous/Core.fs
+++ b/src/Fabulous/Core.fs
@@ -1,5 +1,7 @@
 ﻿namespace Fabulous
 
+open System.Collections.Generic
+
 /// Dev notes:
 ///
 /// The types in this file will be the ones used the most internally by Fabulous.
@@ -60,7 +62,8 @@ and [<Struct>] Widget =
         WidgetCollectionAttributes: WidgetCollectionAttribute []
     }
 
-type [<Struct; RequireQualifiedAccess>] ScalarChange =
+[<Struct; RequireQualifiedAccess>]
+type ScalarChange =
     | Added of added: ScalarAttribute
     | Removed of removed: ScalarAttribute
     | Updated of updated: ScalarAttribute
@@ -88,21 +91,29 @@ and [<Struct>] WidgetDiff =
         WidgetChanges: WidgetChange []
         WidgetCollectionChanges: WidgetCollectionChange []
     }
-    
+
 /// Context of the whole view tree
-type [<Struct>] ViewTreeContext =
-    { CanReuseView: Widget -> Widget -> bool
-      GetViewNode: obj -> IViewNode
-      Dispatch: obj -> unit }
-    
+[<Struct>]
+type ViewTreeContext =
+    {
+        CanReuseView: Widget -> Widget -> bool
+        GetViewNode: obj -> IViewNode
+        Dispatch: obj -> unit
+    }
+
 and IViewNode =
     abstract member Target : obj
     abstract member Parent : IViewNode voption
     abstract member TreeContext : ViewTreeContext
     abstract member MapMsg : (obj -> obj) voption with get, set
-    abstract member GetViewNodeForChild: obj -> IViewNode
+
+    // whatever we need to attach to ViewNode in Core
+    // TODO if it is for internal use only it is possible that we should strongly type
+    // values we can expect in here
+    abstract member PropertyBag : Dictionary<int, obj>
+    abstract member GetViewNodeForChild : obj -> IViewNode
     abstract member TryGetHandler<'T> : AttributeKey -> 'T voption
     abstract member SetHandler<'T> : AttributeKey * 'T voption -> unit
-    abstract member ApplyScalarDiffs : ScalarChange[] -> unit
-    abstract member ApplyWidgetDiffs : WidgetChange[] -> unit
-    abstract member ApplyWidgetCollectionDiffs : WidgetCollectionChange[] -> unit
+    abstract member ApplyScalarDiffs : ScalarChange [] -> unit
+    abstract member ApplyWidgetDiffs : WidgetChange [] -> unit
+    abstract member ApplyWidgetCollectionDiffs : WidgetCollectionChange [] -> unit

--- a/src/Fabulous/Core.fs
+++ b/src/Fabulous/Core.fs
@@ -111,7 +111,6 @@ and IViewNode =
     // thus makes sense to have overhead of boxing
     // in order to save space
     abstract member MemoizedWidget : Widget option with get, set
-    abstract member GetViewNodeForChild : obj -> IViewNode
     abstract member TryGetHandler<'T> : AttributeKey -> 'T voption
     abstract member SetHandler<'T> : AttributeKey * 'T voption -> unit
     abstract member ApplyScalarDiffs : ScalarChange [] -> unit

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -18,6 +18,8 @@
     <Compile Include="Runners.fs" />
     <Compile Include="Attributes.fs" />
     <Compile Include="MapMsg.fs" />
+    <Compile Include="Memo.fs" />
+    <Compile Include="ViewNamespace.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="6.0.1" />

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -1,27 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="StackAllocatedCollections.fs" />
-    <None Include="PackageREADME.md" Pack="true" PackagePath="\" />
-    <Compile Include="Core.fs" />
-    <Compile Include="AttributeDefinitions.fs" />
-    <Compile Include="WidgetDefinitions.fs" />
-    <Compile Include="Builders.fs" />
-    <Compile Include="Reconciler.fs" />
-    <Compile Include="ViewNode.fs" />
-    <Compile Include="State.fs" />
-    <Compile Include="Cmd.fs" />
-    <Compile Include="Runners.fs" />
-    <Compile Include="Attributes.fs" />
-    <Compile Include="MapMsg.fs" />
-    <Compile Include="Memo.fs" />
-    <Compile Include="ViewNamespace.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="6.0.1" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="StackAllocatedCollections.fs"/>
+        <None Include="PackageREADME.md" Pack="true" PackagePath="\"/>
+        <Compile Include="Core.fs"/>
+        <Compile Include="AttributeDefinitions.fs"/>
+        <Compile Include="WidgetDefinitions.fs"/>
+        <Compile Include="Builders.fs"/>
+        <Compile Include="Reconciler.fs"/>
+        <Compile Include="ViewNode.fs"/>
+        <Compile Include="State.fs"/>
+        <Compile Include="Cmd.fs"/>
+        <Compile Include="Runners.fs"/>
+        <Compile Include="Memo.fs"/>
+        <Compile Include="Attributes.fs"/>
+        <Compile Include="MapMsg.fs"/>
+        <Compile Include="ViewNamespace.fs"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="6.0.1"/>
+    </ItemGroup>
 </Project>

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -5,23 +5,23 @@
         <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Include="StackAllocatedCollections.fs"/>
-        <None Include="PackageREADME.md" Pack="true" PackagePath="\"/>
-        <Compile Include="Core.fs"/>
-        <Compile Include="AttributeDefinitions.fs"/>
-        <Compile Include="WidgetDefinitions.fs"/>
-        <Compile Include="Builders.fs"/>
-        <Compile Include="Reconciler.fs"/>
-        <Compile Include="ViewNode.fs"/>
-        <Compile Include="State.fs"/>
-        <Compile Include="Cmd.fs"/>
-        <Compile Include="Runners.fs"/>
-        <Compile Include="Memo.fs"/>
-        <Compile Include="Attributes.fs"/>
-        <Compile Include="MapMsg.fs"/>
-        <Compile Include="ViewNamespace.fs"/>
+        <Compile Include="StackAllocatedCollections.fs" />
+        <None Include="PackageREADME.md" Pack="true" PackagePath="\" />
+        <Compile Include="Core.fs" />
+        <Compile Include="AttributeDefinitions.fs" />
+        <Compile Include="WidgetDefinitions.fs" />
+        <Compile Include="Builders.fs" />
+        <Compile Include="Reconciler.fs" />
+        <Compile Include="ViewNode.fs" />
+        <Compile Include="State.fs" />
+        <Compile Include="Cmd.fs" />
+        <Compile Include="Runners.fs" />
+        <Compile Include="Attributes.fs" />
+        <Compile Include="MapMsg.fs" />
+        <Compile Include="Memo.fs" />
+        <Compile Include="View.fs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="6.0.1"/>
+        <PackageReference Update="FSharp.Core" Version="6.0.1" />
     </ItemGroup>
 </Project>

--- a/src/Fabulous/MapMsg.fs
+++ b/src/Fabulous/MapMsg.fs
@@ -1,18 +1,12 @@
 namespace Fabulous
 
-module View =
+module MapMsg =
     let MapMsg =
-        Attributes.defineScalarWithConverter<obj -> obj, _> "Fabulous_MapMsg" id ScalarAttributeComparers.noCompare (fun (value, node) ->
-            match value with
-            | ValueNone -> node.MapMsg <- ValueNone
-            | ValueSome fn -> node.MapMsg <- ValueSome fn
-        )
-        
-    let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =
-        let fnWithBoxing =
-            fun (msg: obj) -> msg |> unbox<'oldMsg> |> fn |> box
-
-        let builder =
-            x.AddScalar(MapMsg.WithValue fnWithBoxing)
-
-        WidgetBuilder<'newMsg, 'marker>(builder.Key, builder.Attributes)
+        Attributes.defineScalarWithConverter<obj -> obj, _>
+            "Fabulous_MapMsg"
+            id
+            ScalarAttributeComparers.noCompare
+            (fun (value, node) ->
+                match value with
+                | ValueNone -> node.MapMsg <- ValueNone
+                | ValueSome fn -> node.MapMsg <- ValueSome fn)

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -42,8 +42,8 @@ module Memo =
         | (true, true) ->
             match next.KeyComparer next.KeyData prev.KeyData with
             | true -> ScalarAttributeComparison.Identical
-            | false -> ScalarAttributeComparison.Different null
-        | _ -> ScalarAttributeComparison.Different null
+            | false -> ScalarAttributeComparison.Different
+        | _ -> ScalarAttributeComparison.Different
 
     let private updateNode (data: MemoData voption, node: IViewNode) : unit =
         match data with

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -1,23 +1,59 @@
 namespace Fabulous
 
 open System
+open Fabulous
 
 module Memo =
 
     type internal MemoData =
         {
-            Data: obj
-            Comparer: obj -> obj -> bool
+            /// Captures type of data that memoization depends on
+            KeyData: obj
+
+            // comparer that remembers KeyType internally
+            KeyComparer: obj -> obj -> bool
+
+            /// Lambda that users provide
             CreateWidget: obj -> Widget
+
+            /// Captures type of data that memoization depends on
             KeyType: Type
+
+            /// Captures position of a function that produces a widget
+            MarkerType: Type
         }
 
     type Memoized<'t> = { phantom: 't }
 
     let internal MemoAttributeKey = AttributeDefinitionStore.getNextKey()
 
+    let inline private getMemoData (widget: Widget) : MemoData =
+        (widget.ScalarAttributes
+         |> Array.find(fun a -> a.Key = MemoAttributeKey))
+            .Value
+        :?> MemoData
+
+    let internal canReuseMemoizedViewNode prev next =
+        (getMemoData prev).MarkerType = (getMemoData next).MarkerType
+
     let internal compareAttributes (prev: MemoData, next: MemoData) : ScalarAttributeComparison =
-        ScalarAttributeComparison.Identical
+        match (prev.KeyType = next.KeyType, prev.MarkerType = next.MarkerType) with
+        | (true, true) ->
+            match next.KeyComparer next.KeyData prev.KeyData with
+            | true -> ScalarAttributeComparison.Identical
+            | false -> ScalarAttributeComparison.Different null
+        | _ -> ScalarAttributeComparison.Different null
+
+    let private updateNode (data: MemoData voption, node: IViewNode) : unit =
+        match data with
+        | ValueSome memoData ->
+            let memoizedWidget = memoData.CreateWidget memoData.KeyData
+
+            // TODO how to get prev widget?!?
+
+            Reconciler.update node.TreeContext.CanReuseView ValueNone memoizedWidget node
+
+        | ValueNone -> ()
 
     let internal MemoAttribute =
         {
@@ -25,7 +61,7 @@ module Memo =
             Name = "MemoAttribute"
             Convert = id
             Compare = compareAttributes
-            UpdateNode = failwith "should never happen?"
+            UpdateNode = updateNode
         }
 
     AttributeDefinitionStore.set MemoAttributeKey MemoAttribute
@@ -39,13 +75,10 @@ module Memo =
             Name = "Memo"
             CreateView =
                 fun (widget, context, parentNode) ->
-                    let memoData =
-                        (widget.ScalarAttributes
-                         |> Array.find(fun a -> a.Key = MemoAttributeKey))
-                            .Value
-                        :?> MemoData
 
-                    let memoizedWidget = memoData.CreateWidget memoData.Data
+                    let memoData = getMemoData widget
+
+                    let memoizedWidget = memoData.CreateWidget memoData.KeyData
 
                     let memoizedDef =
                         WidgetDefinitionStore.get memoizedWidget.Key

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -1,0 +1,56 @@
+namespace Fabulous
+
+open System
+
+module Memo =
+
+    type internal MemoData =
+        {
+            Data: obj
+            Comparer: obj -> obj -> bool
+            CreateWidget: obj -> Widget
+            KeyType: Type
+        }
+
+    type Memoized<'t> = { phantom: 't }
+
+    let internal MemoAttributeKey = AttributeDefinitionStore.getNextKey()
+
+    let internal compareAttributes (prev: MemoData, next: MemoData) : ScalarAttributeComparison =
+        ScalarAttributeComparison.Identical
+
+    let internal MemoAttribute =
+        {
+            Key = MemoAttributeKey
+            Name = "MemoAttribute"
+            Convert = id
+            Compare = compareAttributes
+            UpdateNode = failwith "should never happen?"
+        }
+
+    AttributeDefinitionStore.set MemoAttributeKey MemoAttribute
+
+
+    let MemoWidgetKey = WidgetDefinitionStore.getNextKey()
+
+    let private widgetDefinition: WidgetDefinition =
+        {
+            Key = MemoWidgetKey
+            Name = "Memo"
+            CreateView =
+                fun (widget, context, parentNode) ->
+                    let memoData =
+                        (widget.ScalarAttributes
+                         |> Array.find(fun a -> a.Key = MemoAttributeKey))
+                            .Value
+                        :?> MemoData
+
+                    let memoizedWidget = memoData.CreateWidget memoData.Data
+
+                    let memoizedDef =
+                        WidgetDefinitionStore.get memoizedWidget.Key
+
+                    memoizedDef.CreateView(memoizedWidget, context, parentNode)
+        }
+
+    WidgetDefinitionStore.set MemoWidgetKey widgetDefinition

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -34,7 +34,7 @@ module Memo =
         | _ -> failwith "Memo widget cannot have extra attributes"
 
 
-    let internal canReuseMemoizedViewNode prev next =
+    let internal canReuseMemoizedWidget prev next =
         (getMemoData prev).MarkerType = (getMemoData next).MarkerType
 
     let private compareAttributes (prev: MemoData, next: MemoData) : ScalarAttributeComparison =

--- a/src/Fabulous/Reconciler.fs
+++ b/src/Fabulous/Reconciler.fs
@@ -8,14 +8,13 @@ module Reconciler =
     /// 2. there are few elements, we expect to have only a handful of them per widget
     /// 3. stable, which is handy for duplicate attributes, e.g. we can choose which one to pick
     /// https://en.wikipedia.org/wiki/Insertion_sort
-    let inline private sortAttributesInPlace (getKey: 'T -> AttributeKey) (attrs: 'T []) : 'T [] =
+    let inline private sortAttributesInPlace (getKey: 'T -> AttributeKey) (attrs: 'T[]) : 'T[] =
         let N = attrs.GetLength(0)
 
         for i in [ 1 .. N - 1 ] do
             for j = i downto 1 do
                 let key = getKey attrs.[j]
-                let prevKey = getKey(attrs.[j - 1])
-
+                let prevKey = getKey (attrs.[j - 1])
                 if key < prevKey then
                     let temp = attrs.[j]
                     attrs.[j] <- attrs.[j - 1]
@@ -46,15 +45,10 @@ module Reconciler =
     ///         compare values
     ///
     /// break when we reached both ends of the arrays
-    let rec diffScalarAttributes (prev: ScalarAttribute []) (next: ScalarAttribute []) : ScalarChange [] =
+    let rec diffScalarAttributes (prev: ScalarAttribute []) (next: ScalarAttribute []) : ScalarChange[] =
         // the order of attributes doesn't matter, thus it is safe to mutate array in place
-        prev
-        |> sortAttributesInPlace(fun a -> a.Key)
-        |> ignore
-
-        next
-        |> sortAttributesInPlace(fun a -> a.Key)
-        |> ignore
+        prev |> sortAttributesInPlace (fun a -> a.Key) |> ignore
+        next |> sortAttributesInPlace (fun a -> a.Key) |> ignore
 
         let mutable result: ScalarChange list = []
 
@@ -111,7 +105,8 @@ module Reconciler =
                         | ScalarAttributeComparison.Identical -> ValueNone
 
                         // New value completely replaces the old value
-                        | ScalarAttributeComparison.Different value -> ValueSome(ScalarChange.Updated nextAttr)
+                        | ScalarAttributeComparison.Different value ->
+                            ValueSome (ScalarChange.Updated(nextAttr))
 
                     match changeOpt with
                     | ValueNone -> ()
@@ -119,19 +114,10 @@ module Reconciler =
 
         List.rev result |> List.toArray
 
-    and diffWidgetAttributes
-        (canReuseView: Widget -> Widget -> bool)
-        (prev: WidgetAttribute [])
-        (next: WidgetAttribute [])
-        : WidgetChange [] =
+    and diffWidgetAttributes (canReuseView: Widget -> Widget -> bool) (prev: WidgetAttribute []) (next: WidgetAttribute []) : WidgetChange[] =
         // the order of attributes doesn't matter, thus it is safe to mutate array in place
-        prev
-        |> sortAttributesInPlace(fun a -> a.Key)
-        |> ignore
-
-        next
-        |> sortAttributesInPlace(fun a -> a.Key)
-        |> ignore
+        prev |> sortAttributesInPlace (fun a -> a.Key) |> ignore
+        next |> sortAttributesInPlace (fun a -> a.Key) |> ignore
 
         let mutable result: WidgetChange list = []
 
@@ -186,9 +172,9 @@ module Reconciler =
                         elif canReuseView prevWidget nextWidget then
                             match diffWidget canReuseView (ValueSome prevWidget) nextWidget with
                             | ValueNone -> ValueNone
-                            | ValueSome diffs -> ValueSome(WidgetChange.Updated struct (nextAttr, diffs))
+                            | ValueSome diffs -> ValueSome (WidgetChange.Updated struct (nextAttr, diffs))
                         else
-                            ValueSome(WidgetChange.ReplacedBy nextAttr)
+                            ValueSome (WidgetChange.ReplacedBy nextAttr)
 
                     match changeOpt with
                     | ValueNone -> ()
@@ -196,19 +182,10 @@ module Reconciler =
 
         List.rev result |> List.toArray
 
-    and diffWidgetCollectionAttributes
-        (canReuseView: Widget -> Widget -> bool)
-        (prev: WidgetCollectionAttribute [])
-        (next: WidgetCollectionAttribute [])
-        : WidgetCollectionChange [] =
+    and diffWidgetCollectionAttributes (canReuseView: Widget -> Widget -> bool) (prev: WidgetCollectionAttribute[]) (next: WidgetCollectionAttribute[]): WidgetCollectionChange[] =
         // the order of attributes doesn't matter, thus it is safe to mutate array in place
-        prev
-        |> sortAttributesInPlace(fun a -> a.Key)
-        |> ignore
-
-        next
-        |> sortAttributesInPlace(fun a -> a.Key)
-        |> ignore
+        prev |> sortAttributesInPlace (fun a -> a.Key) |> ignore
+        next |> sortAttributesInPlace (fun a -> a.Key) |> ignore
 
         let mutable result: WidgetCollectionChange list = []
 
@@ -221,18 +198,12 @@ module Reconciler =
         while not(prevIndex >= prevLength && nextIndex >= nextLength) do
             if prevIndex = prevLength then
                 // that means we are done with the prev and only need to add next's tail to added
-                result <-
-                    WidgetCollectionChange.Added next.[nextIndex]
-                    :: result
-
+                result <- WidgetCollectionChange.Added next.[nextIndex] :: result
                 nextIndex <- nextIndex + 1
 
             elif nextIndex = nextLength then
                 // that means that we are done with new items and only need prev's tail to removed
-                result <-
-                    WidgetCollectionChange.Removed prev.[prevIndex]
-                    :: result
-
+                result <- WidgetCollectionChange.Removed prev.[prevIndex] :: result
                 prevIndex <- prevIndex + 1
 
             else
@@ -264,18 +235,13 @@ module Reconciler =
                     nextIndex <- nextIndex + 1
 
                     let change =
-                        WidgetCollectionChange.Updated
-                            struct (nextAttr, diffWidgetCollections canReuseView prevWidgetColl nextWidgetColl)
+                        WidgetCollectionChange.Updated struct (nextAttr, diffWidgetCollections canReuseView prevWidgetColl nextWidgetColl)
 
                     result <- change :: result
 
         List.rev result |> List.toArray
 
-    and diffWidgetCollections
-        (canReuseView: Widget -> Widget -> bool)
-        (prev: Widget array)
-        (next: Widget array)
-        : WidgetCollectionItemChange [] =
+    and diffWidgetCollections (canReuseView: Widget -> Widget -> bool) (prev: Widget array) (next: Widget array) : WidgetCollectionItemChange[] =
         let mutable target = []
 
         if prev.Length > next.Length then
@@ -288,15 +254,15 @@ module Reconciler =
 
             let changeOpt =
                 match prevItemOpt with
-                | None -> ValueSome(WidgetCollectionItemChange.Insert struct (i, currItem))
+                | None -> ValueSome (WidgetCollectionItemChange.Insert struct (i, currItem))
 
                 | Some prevItem when canReuseView prevItem currItem ->
-
+                    
                     match diffWidget canReuseView (ValueSome prevItem) currItem with
                     | ValueNone -> ValueNone
-                    | ValueSome diffs -> ValueSome(WidgetCollectionItemChange.Update struct (i, diffs))
+                    | ValueSome diffs -> ValueSome (WidgetCollectionItemChange.Update struct (i, diffs))
 
-                | Some _ -> ValueSome(WidgetCollectionItemChange.Replace struct (i, currItem))
+                | Some _ -> ValueSome (WidgetCollectionItemChange.Replace struct (i, currItem))
 
             match changeOpt with
             | ValueNone -> ()
@@ -304,62 +270,28 @@ module Reconciler =
 
         List.rev target |> List.toArray
 
-    and diffWidget
-        (canReuseView: Widget -> Widget -> bool)
-        (prevOpt: Widget voption)
-        (next: Widget)
-        : WidgetDiff voption =
-        let prevScalarAttributes =
-            match prevOpt with
-            | ValueNone -> Array.empty
-            | ValueSome widget -> widget.ScalarAttributes
+    and diffWidget (canReuseView: Widget -> Widget -> bool) (prevOpt: Widget voption) (next: Widget): WidgetDiff voption =
+        let prevScalarAttributes = match prevOpt with ValueNone -> Array.empty | ValueSome widget -> widget.ScalarAttributes
+        let prevWidgetAttributes = match prevOpt with ValueNone -> Array.empty | ValueSome widget -> widget.WidgetAttributes
+        let prevWidgetCollectionAttributes = match prevOpt with ValueNone -> Array.empty | ValueSome widget -> widget.WidgetCollectionAttributes
 
-        let prevWidgetAttributes =
-            match prevOpt with
-            | ValueNone -> Array.empty
-            | ValueSome widget -> widget.WidgetAttributes
+        let scalarDiffs = diffScalarAttributes prevScalarAttributes next.ScalarAttributes
+        let widgetDiffs = diffWidgetAttributes canReuseView prevWidgetAttributes next.WidgetAttributes
+        let collectionDiffs = diffWidgetCollectionAttributes canReuseView prevWidgetCollectionAttributes next.WidgetCollectionAttributes
 
-        let prevWidgetCollectionAttributes =
-            match prevOpt with
-            | ValueNone -> Array.empty
-            | ValueSome widget -> widget.WidgetCollectionAttributes
-
-        let scalarDiffs =
-            diffScalarAttributes prevScalarAttributes next.ScalarAttributes
-
-        let widgetDiffs =
-            diffWidgetAttributes canReuseView prevWidgetAttributes next.WidgetAttributes
-
-        let collectionDiffs =
-            diffWidgetCollectionAttributes canReuseView prevWidgetCollectionAttributes next.WidgetCollectionAttributes
-
-        if scalarDiffs.Length = 0
-           && widgetDiffs.Length = 0
-           && collectionDiffs.Length = 0 then
+        if scalarDiffs.Length = 0 && widgetDiffs.Length = 0 && collectionDiffs.Length = 0 then
             ValueNone
         else
             ValueSome
-                {
-                    ScalarChanges = scalarDiffs
-                    WidgetChanges = widgetDiffs
-                    WidgetCollectionChanges = collectionDiffs
-                }
+                { ScalarChanges = scalarDiffs
+                  WidgetChanges = widgetDiffs
+                  WidgetCollectionChanges = collectionDiffs }
 
     /// Diffs changes and applies them on the target
-    let rec update
-        (canReuseView: Widget -> Widget -> bool)
-        (prevOpt: Widget voption)
-        (next: Widget)
-        (node: IViewNode)
-        : unit =
+    let rec update (canReuseView: Widget -> Widget -> bool) (prevOpt: Widget voption) (next: Widget) (node: IViewNode) : unit =
         match diffWidget canReuseView prevOpt next with
         | ValueNone -> ()
         | ValueSome diff ->
-            if diff.ScalarChanges.Length > 0 then
-                node.ApplyScalarDiffs(diff.ScalarChanges)
-
-            if diff.WidgetChanges.Length > 0 then
-                node.ApplyWidgetDiffs(diff.WidgetChanges)
-
-            if diff.WidgetCollectionChanges.Length > 0 then
-                node.ApplyWidgetCollectionDiffs(diff.WidgetCollectionChanges)
+            if diff.ScalarChanges.Length > 0 then node.ApplyScalarDiffs(diff.ScalarChanges)
+            if diff.WidgetChanges.Length > 0 then node.ApplyWidgetDiffs(diff.WidgetChanges)
+            if diff.WidgetCollectionChanges.Length > 0 then node.ApplyWidgetCollectionDiffs(diff.WidgetCollectionChanges)

--- a/src/Fabulous/Reconciler.fs
+++ b/src/Fabulous/Reconciler.fs
@@ -105,7 +105,7 @@ module Reconciler =
                         | ScalarAttributeComparison.Identical -> ValueNone
 
                         // New value completely replaces the old value
-                        | ScalarAttributeComparison.Different value ->
+                        | ScalarAttributeComparison.Different ->
                             ValueSome (ScalarChange.Updated(nextAttr))
 
                     match changeOpt with

--- a/src/Fabulous/Runners.fs
+++ b/src/Fabulous/Runners.fs
@@ -11,7 +11,7 @@ type Program<'arg, 'model, 'msg> =
         View: 'model -> Widget
         CanReuseView: Widget -> Widget -> bool
     }
-
+    
 type IRunner =
     interface
     end
@@ -21,7 +21,7 @@ type IViewAdapter =
     abstract CreateView : unit -> obj
     abstract Attach : obj -> unit
     abstract Detach : bool -> unit
-
+    
 module RunnerStore =
     let private _runners = Dictionary<StateKey, IRunner>()
 
@@ -30,26 +30,23 @@ module RunnerStore =
     let remove key = _runners.Remove(key) |> ignore
 
 module ViewAdapterStore =
-    let private _viewAdapters =
-        Dictionary<ViewAdapterKey, IViewAdapter>()
-
+    let private _viewAdapters = Dictionary<ViewAdapterKey, IViewAdapter>()
     let mutable private _nextKey = 0
-
+    
     let get key = _viewAdapters.[key]
     let set key value = _viewAdapters.[key] <- value
-
     let remove key =
         match _viewAdapters.TryGetValue(key) with
         | false, _ -> ()
         | true, value ->
             value.Dispose()
             _viewAdapters.Remove(key) |> ignore
-
+            
     let getNextKey () : ViewAdapterKey =
         let key = _nextKey
         _nextKey <- _nextKey + 1
         key
-
+        
 /// Runners are responsible for the Model-Update part of MVU.
 /// They read from and update StateStore.
 module Runners =
@@ -75,9 +72,9 @@ module Runners =
 
         member _.Key = key
         member _.Program = program
-
+            
         member _.Dispatch(msg) = processMsg msg
-
+        
 
         member _.Start(arg) = start arg
         member _.Pause() = ()
@@ -112,7 +109,7 @@ module ViewAdapters =
 
         let _stateSubscription =
             StateStore.StateChanged.Subscribe(this.OnStateChanged)
-
+            
         member private _.Dispatch(msg) =
             if _allowDispatch then
                 dispatch(unbox msg)
@@ -121,18 +118,16 @@ module ViewAdapters =
             let state = unbox(StateStore.get stateKey)
             let widget = view state
             _widget <- widget
-
+            
             let treeContext =
-                {
-                    CanReuseView = canReuseView
-                    GetViewNode = getViewNode
-                    Dispatch = this.Dispatch
-                }
-
+                {  CanReuseView = canReuseView
+                   GetViewNode = getViewNode
+                   Dispatch = this.Dispatch }
+                
             let definition = WidgetDefinitionStore.get widget.Key
-
+            
             let struct (_node, root) =
-                definition.CreateView(widget, treeContext, ValueNone)
+                 definition.CreateView(widget, treeContext, ValueNone)
 
             _root <- root
             _root
@@ -145,7 +140,7 @@ module ViewAdapters =
                 let prevWidget = _widget
                 let currentWidget = view state
                 _widget <- currentWidget
-
+                
                 let node = getViewNode _root
 
                 // TODO handle the case when Type of the widget changes
@@ -175,3 +170,4 @@ module ViewAdapters =
 
         ViewAdapterStore.set key viewAdapter
         viewAdapter
+

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -7,7 +7,7 @@ module ViewHelpers =
         if not(prevKey = currWidget.Key) then
             false
         else if (prevKey = Memo.MemoWidgetKey) then
-            Memo.canReuseMemoizedViewNode prevWidget currWidget
+            Memo.canReuseMemoizedWidget prevWidget currWidget
         else
             true
 

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -1,6 +1,15 @@
 namespace Fabulous
 
+module ViewHelpers =
+    let canReuseView (prevWidget: Widget) (currWidget: Widget) =
+        let prevKey = prevWidget.Key
 
+        if not(prevKey = currWidget.Key) then
+            false
+        else if (prevKey = Memo.MemoWidgetKey) then
+            Memo.canReuseMemoizedViewNode prevWidget currWidget
+        else
+            true
 
 module View =
     let memo<'msg, 'key, 'marker when 'key: equality>

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -22,8 +22,8 @@ module View =
                 KeyData = box key
                 KeyComparer = fun (prev: obj) (next: obj) -> unbox<'key> prev = unbox<'key> next
                 CreateWidget = fun k -> (fn(unbox<'key> k)).Compile()
-                KeyTypeHash = typeof<'key>.GetHashCode ()
-                MarkerTypeHash = typeof<'marker>.GetHashCode ()
+                KeyType = typeof<'key>
+                MarkerType = typeof<'marker>
             }
 
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(

--- a/src/Fabulous/ViewNamespace.fs
+++ b/src/Fabulous/ViewNamespace.fs
@@ -1,0 +1,30 @@
+namespace Fabulous
+
+
+module View =
+    let memo<'msg, 'key, 'marker when 'key: equality>
+        (key: 'key)
+        (fn: 'key -> WidgetBuilder<'msg, 'marker>)
+        : WidgetBuilder<'msg, Memo.Memoized<'marker>> =
+
+        let memo: Memo.MemoData =
+            {
+                Data = box key
+                Comparer = fun (prev: obj) (next: obj) -> unbox<'key> prev = unbox<'key> next
+                CreateWidget = fun k -> (fn(unbox<'key> k)).Compile()
+                KeyType = typeof<'key>
+            }
+
+        WidgetBuilder<'msg, Memo.Memoized<'marker>>(
+            Memo.MemoWidgetKey,
+            struct ([| Memo.MemoAttribute.WithValue(memo) |], [||], [||])
+        )
+
+    let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =
+        let fnWithBoxing =
+            fun (msg: obj) -> msg |> unbox<'oldMsg> |> fn |> box
+
+        let builder =
+            x.AddScalar(MapMsg.MapMsg.WithValue fnWithBoxing)
+
+        WidgetBuilder<'newMsg, 'marker>(builder.Key, builder.Attributes)

--- a/src/Fabulous/ViewNamespace.fs
+++ b/src/Fabulous/ViewNamespace.fs
@@ -9,10 +9,11 @@ module View =
 
         let memo: Memo.MemoData =
             {
-                Data = box key
-                Comparer = fun (prev: obj) (next: obj) -> unbox<'key> prev = unbox<'key> next
+                KeyData = box key
+                KeyComparer = fun (prev: obj) (next: obj) -> unbox<'key> prev = unbox<'key> next
                 CreateWidget = fun k -> (fn(unbox<'key> k)).Compile()
                 KeyType = typeof<'key>
+                MarkerType = typeof<'marker>
             }
 
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(

--- a/src/Fabulous/ViewNamespace.fs
+++ b/src/Fabulous/ViewNamespace.fs
@@ -1,6 +1,7 @@
 namespace Fabulous
 
 
+
 module View =
     let memo<'msg, 'key, 'marker when 'key: equality>
         (key: 'key)
@@ -12,8 +13,8 @@ module View =
                 KeyData = box key
                 KeyComparer = fun (prev: obj) (next: obj) -> unbox<'key> prev = unbox<'key> next
                 CreateWidget = fun k -> (fn(unbox<'key> k)).Compile()
-                KeyType = typeof<'key>
-                MarkerType = typeof<'marker>
+                KeyTypeHash = typeof<'key>.GetHashCode ()
+                MarkerTypeHash = typeof<'marker>.GetHashCode ()
             }
 
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -1,6 +1,5 @@
 ﻿namespace Fabulous
 
-open System.Collections.Generic
 open Fabulous
 
 /// Define the logic to apply diffs and store event handlers of its target control
@@ -10,14 +9,13 @@ type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targe
     // also we can probably use just Dictionary instead of Map because
     // ViewNode is supposed to be mutable, stateful and persistent object
     let mutable _handlers: Map<AttributeKey, obj> = Map.empty
-    let mutable _mapMsg: (obj -> obj) voption = ValueNone
 
     interface IViewNode with
         member _.Target = targetRef.Target
         member _.TreeContext = treeContext
         member _.Parent = parentNode
-        member val MapMsg = _mapMsg with get, set
-        member val PropertyBag = Dictionary()
+        member val MapMsg: (obj -> obj) voption = ValueNone with get, set
+        member val MemoizedWidget: Widget option = None with get, set
 
         member _.GetViewNodeForChild(child) = treeContext.GetViewNode(child)
 

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -1,25 +1,30 @@
 ﻿namespace Fabulous
 
+open System.Collections.Generic
 open Fabulous
 
 /// Define the logic to apply diffs and store event handlers of its target control
 type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targetRef: System.WeakReference) =
+
+    // TODO consider combine handlers mapMsg and property bag
+    // also we can probably use just Dictionary instead of Map because
+    // ViewNode is supposed to be mutable, stateful and persistent object
     let mutable _handlers: Map<AttributeKey, obj> = Map.empty
     let mutable _mapMsg: (obj -> obj) voption = ValueNone
-    
+
     interface IViewNode with
         member _.Target = targetRef.Target
         member _.TreeContext = treeContext
         member _.Parent = parentNode
         member val MapMsg = _mapMsg with get, set
-        
-        member _.GetViewNodeForChild(child) =
-            treeContext.GetViewNode(child)
+        member val PropertyBag = Dictionary()
+
+        member _.GetViewNodeForChild(child) = treeContext.GetViewNode(child)
 
         member _.TryGetHandler<'T>(key: AttributeKey) =
             match Map.tryFind key _handlers with
             | None -> ValueNone
-            | Some v -> ValueSome (unbox<'T> v)
+            | Some v -> ValueSome(unbox<'T> v)
 
         member _.SetHandler<'T>(key: AttributeKey, handlerOpt: 'T voption) =
             _handlers <-

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -17,8 +17,6 @@ type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targe
         member val MapMsg: (obj -> obj) voption = ValueNone with get, set
         member val MemoizedWidget: Widget option = None with get, set
 
-        member _.GetViewNodeForChild(child) = treeContext.GetViewNode(child)
-
         member _.TryGetHandler<'T>(key: AttributeKey) =
             match Map.tryFind key _handlers with
             | None -> ValueNone

--- a/src/Fabulous/WidgetDefinitions.fs
+++ b/src/Fabulous/WidgetDefinitions.fs
@@ -5,18 +5,22 @@ open Fabulous
 
 /// Widget definition to create a control
 type WidgetDefinition =
-    { Key: WidgetKey
-      Name: string
-      CreateView: Widget * ViewTreeContext * IViewNode voption -> obj }
-    
+    {
+        Key: WidgetKey
+        Name: string
+        CreateView: Widget * ViewTreeContext * IViewNode voption -> struct (IViewNode * obj)
+    }
+
 module WidgetDefinitionStore =
-    let private _widgets = Dictionary<WidgetKey, WidgetDefinition>()
+    let private _widgets =
+        Dictionary<WidgetKey, WidgetDefinition>()
+
     let mutable private _nextKey = 0
-    
+
     let get key = _widgets.[key]
     let set key value = _widgets.[key] <- value
     let remove key = _widgets.Remove(key) |> ignore
-    
+
     let getNextKey () : WidgetKey =
         let key = _nextKey
         _nextKey <- _nextKey + 1


### PR DESCRIPTION
Fixes https://github.com/TimLariviere/Fabulous-new/issues/18

## Intro 

This adds support for `View.memo` that can be used to optimize rerenders

Here is a minimal usage example (from tests)

```fsharp
Stack() {
    View.memo
        model.someValue
        (fun value -> VerySlowLabel(string value))
}
```

Lambda won't be called unless `model.someValue` changes, thus skipping time to render `VerySlowLabel` and diffing it

## How it works

### Memo Attribute

`View.memo` produces a new `WidgetBuilder` that captures all needed info in a `Attribute`

Here is the type definition of the attribute value

```fsharp
type internal MemoData =
    {
        /// Captures data that memoization depends on
        KeyData: obj

        // comparer that remembers KeyType internally
        KeyComparer: obj -> obj -> bool

        /// wrapped untyped lambda that users provide
        CreateWidget: obj -> Widget

        /// Captures type hash of data that memoization depends on
        KeyTypeHash: int

        /// Captures type hash of the marker memoized function produces
        MarkerTypeHash: int
    }
```

Then, to avoid adding any other new properties via `.prop` syntax we wrap the marker type in a new type, like so

```fsharp
type Memoized<'t> = { phantom: 't }
```

Note that marker types are needed just for type safety and intellisense, there is no actual instance of `Memoized` ever created.

### View creation

Then we need to be able to create the underlying control (like XF.Page), how do we do that?

Well, there is a trick I used to achieve that:

We register a new WidgetDefinition that redirects creation to the underlying widget, of course, we need to create it first, like  so

```fsharp
let private widgetDefinition: WidgetDefinition =
    {
        Key = MemoWidgetKey
        Name = "Memo"
        CreateView =
            fun (widget, context, parentNode) ->

				  // access the memo data stored in the memo widget
                let memoData = getMemoData widget

                // call the function for the first time to create underlying widget
                let memoizedWidget = memoData.CreateWidget memoData.KeyData

                // get the underlying widget definition
                let memoizedDef =
                    WidgetDefinitionStore.get memoizedWidget.Key

                // create the view and ViewNode using it
                let struct (node, view) =
                    memoizedDef.CreateView(memoizedWidget, context, parentNode)

                // store widget that was used to produce this node
                // to pass it to reconciler later on
                node.PropertyBag.Add(MemoWidgetKey, memoizedWidget)
                struct (node, view)
    }

```


### Updating the view

Ok, now how to handle updates?

1. We need to be able to compare stored `MemoData`  (prev vs cur).

Easy enough:

```fsharp
let private compareAttributes (prev: MemoData, next: MemoData) : ScalarAttributeComparison =
    match (prev.KeyTypeHash = next.KeyTypeHash, prev.MarkerTypeHash = next.MarkerTypeHash) with
    | (true, true) ->
        match next.KeyComparer next.KeyData prev.KeyData with
        | true -> ScalarAttributeComparison.Identical
        | false -> ScalarAttributeComparison.Different null
    | _ -> ScalarAttributeComparison.Different null
```

So we check if captured types are the same and if they are if the actual keys (the first argument to `View.memo`) are equal.

2. Then we need to figure out if we can reuse the ViewNode instance while diffing, that is, if the underlying widget type changed 

```fsharp
let canReuseView (prevWidget: Widget) (currWidget: Widget) =
    let prevKey = prevWidget.Key

    if not(prevKey = currWidget.Key) then
        false
    else if (prevKey = Memo.MemoWidgetKey) then
        // even if the WidgetKey is the same, e.g. Memo.MemoWidgetKey
        // it doesn't mean that underlying widget is of the same type
        Memo.canReuseMemoizedViewNode prevWidget currWidget
    else
        true

// in Memo.fs
let internal canReuseMemoizedViewNode prev next =
    // check the captured type, Example `IButton` marker
    (getMemoData prev).MarkerTypeHash = (getMemoData next).MarkerTypeHash
```


3. Ok, given that the underlying type is the same and `compareAttributes` returned `ScalarAttributeComparison.Different` what do we do next?

```fsharp
let private updateNode (data: MemoData voption, node: IViewNode) : unit =
    match data with
    | ValueSome memoData ->
        let memoizedWidget = memoData.CreateWidget memoData.KeyData
        let propBag = node.PropertyBag

        // remember that we added widget to propBag?
        // that is exactly why we did that, to pass to diffing
        let prevWidget =
            match propBag.TryGetValue MemoWidgetKey with
            | true, value -> ValueSome(unbox<Widget> value)
            | _ -> ValueNone

        // update stored widget for future diffing
        propBag.[MemoWidgetKey] <- memoizedWidget
			
        // invoke reconciler manually  
        Reconciler.update node.TreeContext.CanReuseView prevWidget memoizedWidget node
    
    // this should actually never happen, MemoWidget should always have MemoAttribute
    | ValueNone -> () 
```


## Caveats/Notes
1. To support `Memoized<'marker>` we need to add one more extension method per collection type, shouldn’t be too bad. Plus it is done either by us (maintainers) or by advanced users of Fabulous. Thus, I feel ok about that.

```fsharp
// copied from tests
[<Extension>]
static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
    (
        _: CollectionBuilder<'msg, 'marker, IMarker>,
        x: WidgetBuilder<'msg, Memo.Memoized<'itemMarker>> // <----
    ) : Content<'msg> =
    { Widgets = [ x.Compile() ] }
```

2. I decided not to capture type of the passed lambda to `View.memo`, but maybe we should, just to be extra safe. Then we need to add the check into `compareAttributes` function
3. ONLY memoize large sub trees, the entire memo machinery is quite expensive, relatively speaking, Thus make sure that you memoize only expensive `view` functions. Example: A collection with several children with large number of attributes. You can apply this rule  `number of widgets + number of attributes > 15` (number are aggregate across entire sub tree)