### PR TITLE
Optimize diffing redo

### DIFF
--- a/samples/Xamarin.Forms/CounterApp/CounterApp/CounterApp.fsproj
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/CounterApp.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     </PropertyGroup>
     <ItemGroup>

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
@@ -13,23 +13,26 @@ type BorderedEntry() =
         BindableProperty.Create("BorderColor", typeof<Color>, typeof<BorderedEntry>, Color.Default)
 
     member this.BorderColor
-        with get () =
-            this.GetValue(BorderedEntry.BorderColorProperty) :?> Color
-        and set (value: Color) =
-            this.SetValue(BorderedEntry.BorderColorProperty, value)
+        with get () = this.GetValue(BorderedEntry.BorderColorProperty) :?> Color
+        and set (value: Color) = this.SetValue(BorderedEntry.BorderColorProperty, value)
 
 [<AutoOpen>]
 module FabulousBorderedEntry =
-    let BorderColor = Attributes.defineBindable<Color> BorderedEntry.BorderColorProperty
+    let BorderColor =
+        Attributes.defineBindable<Color> BorderedEntry.BorderColorProperty
+
     let BorderedEntryKey = Widgets.register<BorderedEntry>()
-    
-    type IBorderedEntry = inherit IEntry
+
+    type IBorderedEntry =
+        inherit IEntry
 
     type Fabulous.XamarinForms.View with
         static member inline BorderedEntry<'msg>(text, onTextChanged: string -> 'msg) =
-            ViewHelpers.buildScalars<'msg, IBorderedEntry> BorderedEntryKey
-                [| Entry.Text.WithValue(text)
-                   Entry.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box) |]
+            WidgetBuilder<'msg, IBorderedEntry>(
+                BorderedEntryKey,
+                Entry.Text.WithValue(text),
+                Entry.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
+            )
 
     [<Extension>]
     type BorderedEntryExtensions =

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
@@ -1,58 +1,89 @@
 ﻿namespace FabulousContacts.Controls
 
 open Fabulous
+open Fabulous.StackAllocatedCollections
 open Fabulous.XamarinForms
 open Xamarin.Forms.Maps
 open System.Runtime.CompilerServices
 
 module Pin =
-    let PinType = Attributes.defineBindable<PinType> Pin.TypeProperty
-    let Label = Attributes.defineBindable<string> Pin.LabelProperty
-    let Position = Attributes.defineBindable<Position> Pin.PositionProperty
-    let Address = Attributes.defineBindable<string> Pin.AddressProperty
+    let PinType =
+        Attributes.defineBindable<PinType> Pin.TypeProperty
+
+    let Label =
+        Attributes.defineBindable<string> Pin.LabelProperty
+
+    let Position =
+        Attributes.defineBindable<Position> Pin.PositionProperty
+
+    let Address =
+        Attributes.defineBindable<string> Pin.AddressProperty
+
     let PinKey = Widgets.register<Pin>()
 
 module Map =
-    let RequestedRegion = Attributes.define<MapSpan> "Map_RequestedRegion" (fun (newValueOpt, node) ->
-        let map = node.Target :?> Map
-        match newValueOpt with
-        | ValueNone -> ()
-        | ValueSome mapSpan -> map.MoveToRegion(mapSpan)
-    )
-    let Pins = Attributes.defineWidgetCollection<Pin> "Map_Pins" (fun target -> (target :?> Map).Pins)
-    let HasZoomEnabled = Attributes.defineBindable<bool> Map.HasZoomEnabledProperty
-    let HasScrollEnabled = Attributes.defineBindable<bool> Map.HasScrollEnabledProperty
+    let RequestedRegion =
+        Attributes.define<MapSpan>
+            "Map_RequestedRegion"
+            (fun (newValueOpt, node) ->
+                let map = node.Target :?> Map
+
+                match newValueOpt with
+                | ValueNone -> ()
+                | ValueSome mapSpan -> map.MoveToRegion(mapSpan))
+
+    let Pins =
+        Attributes.defineWidgetCollection<Pin> "Map_Pins" (fun target -> (target :?> Map).Pins)
+
+    let HasZoomEnabled =
+        Attributes.defineBindable<bool> Map.HasZoomEnabledProperty
+
+    let HasScrollEnabled =
+        Attributes.defineBindable<bool> Map.HasScrollEnabledProperty
+
     let MapKey = Widgets.register<Map>()
 
 module MapView =
-    type IPin = inherit IMarker
-    type IMap = inherit IView
+    type IPin =
+        inherit IMarker
+
+    type IMap =
+        inherit IView
 
     type Fabulous.XamarinForms.View with
         static member inline Pin<'msg>(pinType, label, position) =
-            ViewHelpers.buildScalars<'msg, IPin> Pin.PinKey
-                [| Pin.PinType.WithValue(pinType)
-                   Pin.Label.WithValue(label)
-                   Pin.Position.WithValue(position) |]
-                
+            WidgetBuilder<'msg, IPin>(
+                Pin.PinKey,
+                Pin.PinType.WithValue(pinType),
+                Pin.Label.WithValue(label),
+                Pin.Position.WithValue(position)
+            )
+
         static member inline Map<'msg>(requestedRegion) =
-            ViewHelpers.buildCollection<'msg, IMap, IPin> Map.MapKey Map.Pins
-                [| Map.RequestedRegion.WithValue(requestedRegion) |]
-    
+            CollectionBuilder<'msg, IMap, IPin>(Map.MapKey, Map.Pins, Map.RequestedRegion.WithValue(requestedRegion))
+
     [<Extension>]
     type MapExtensions =
         [<Extension>]
         static member inline address(this: WidgetBuilder<'msg, #IPin>, value: string) =
             this.AddScalar(Pin.Address.WithValue(value))
+
         [<Extension>]
         static member inline hasZoomEnabled(this: WidgetBuilder<'msg, #IMap>, value: bool) =
             this.AddScalar(Map.HasZoomEnabled.WithValue(value))
+
         [<Extension>]
         static member inline hasScrollEnabled(this: WidgetBuilder<'msg, #IMap>, value: bool) =
             this.AddScalar(Map.HasScrollEnabled.WithValue(value))
-            
+
     [<Extension>]
     type CollectionBuilderExtensions =
         [<Extension>]
-        static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPin>(_: CollectionBuilder<'msg, 'marker, IPin>, x: WidgetBuilder<'msg, 'itemType>) : Content<'msg> =
-            { Widgets = [ x.Compile() ] }
+        static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPin>
+            (
+                _: CollectionBuilder<'msg, 'marker, IPin>,
+                x: WidgetBuilder<'msg, 'itemType>
+            ) : Content<'msg> =
+            {
+                Widgets = MutStackArray1.One(x.Compile())
+            }

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/UnderlinedLabel.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/UnderlinedLabel.fs
@@ -1,5 +1,6 @@
 ﻿namespace FabulousContacts.Controls
 
+open Fabulous
 open Fabulous.XamarinForms
 open Fabulous.XamarinForms.XFAttributes
 open Xamarin.Forms
@@ -10,10 +11,10 @@ type UnderlinedLabel() =
 [<AutoOpen>]
 module FabulousUnderlinedLabel =
     let UnderlinedLabelKey = Widgets.register<UnderlinedLabel>()
-    
-    type IUnderlinedLabel = inherit ILabel
+
+    type IUnderlinedLabel =
+        inherit ILabel
 
     type Fabulous.XamarinForms.View with
         static member inline UnderlinedLabel<'msg>(text) =
-            ViewHelpers.buildScalars<'msg, IUnderlinedLabel> UnderlinedLabelKey
-                [| Label.Text.WithValue(text) |]
+            WidgetBuilder<'msg, IUnderlinedLabel>(UnderlinedLabelKey, Label.Text.WithValue(text))

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/FabulousContacts.fsproj
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/FabulousContacts.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     </PropertyGroup>
     <ItemGroup>

--- a/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/FabulousWeather.fsproj
+++ b/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/FabulousWeather.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     </PropertyGroup>
     <ItemGroup>

--- a/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/PancakeView.fs
+++ b/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/PancakeView.fs
@@ -3,6 +3,7 @@
 open Fabulous
 open Fabulous.XamarinForms
 open Fabulous.StackAllocatedCollections
+open Fabulous.StackAllocatedCollections.StackList
 
 [<AutoOpen>]
 module PancakeView =
@@ -29,7 +30,7 @@ module PancakeView =
                 PancakeViewKey,
 
                 AttributesBundle(
-                    StackArray3.one(BackgroundGradientStops.WithValue(backgroundGradientStops)),
+                    StackList.one(BackgroundGradientStops.WithValue(backgroundGradientStops)),
                     Some [| Content.WithValue(content.Compile()) |],
                     None
                 )

--- a/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/PancakeView.fs
+++ b/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/PancakeView.fs
@@ -31,7 +31,7 @@ module PancakeView =
 
                 AttributesBundle(
                     StackList.one(BackgroundGradientStops.WithValue(backgroundGradientStops)),
-                    Some [| Content.WithValue(content.Compile()) |],
-                    None
+                    ValueSome [| Content.WithValue(content.Compile()) |],
+                    ValueNone
                 )
             )

--- a/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/PancakeView.fs
+++ b/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/PancakeView.fs
@@ -2,18 +2,35 @@
 
 open Fabulous
 open Fabulous.XamarinForms
+open Fabulous.StackAllocatedCollections
 
 [<AutoOpen>]
 module PancakeView =
-    let BackgroundGradientStops = Attributes.defineBindable<Xamarin.Forms.PancakeView.GradientStopCollection> Xamarin.Forms.PancakeView.PancakeView.BackgroundGradientStopsProperty
-    let Content = Attributes.defineBindableWidget Xamarin.Forms.PancakeView.PancakeView.ContentProperty
-    let PancakeViewKey = Widgets.register<Xamarin.Forms.PancakeView.PancakeView>()
-    
-    type IPancakeView = inherit IView
+    let BackgroundGradientStops =
+        Attributes.defineBindable<Xamarin.Forms.PancakeView.GradientStopCollection>
+            Xamarin.Forms.PancakeView.PancakeView.BackgroundGradientStopsProperty
+
+    let Content =
+        Attributes.defineBindableWidget Xamarin.Forms.PancakeView.PancakeView.ContentProperty
+
+    let PancakeViewKey =
+        Widgets.register<Xamarin.Forms.PancakeView.PancakeView>()
+
+    type IPancakeView =
+        inherit IView
 
     type Fabulous.XamarinForms.View with
-        static member inline PancakeView<'msg, 'marker when 'marker :> IView>(backgroundGradientStops, content: WidgetBuilder<'msg, 'marker>) =
-            ViewHelpers.build<'msg, IPancakeView> PancakeViewKey
-                [| BackgroundGradientStops.WithValue(backgroundGradientStops) |]
-                [| Content.WithValue(content.Compile()) |]
-                [||]
+        static member inline PancakeView<'msg, 'marker when 'marker :> IView>
+            (
+                backgroundGradientStops,
+                content: WidgetBuilder<'msg, 'marker>
+            ) =
+            WidgetBuilder<'msg, IPancakeView>(
+                PancakeViewKey,
+
+                AttributesBundle(
+                    StackArray3.one(BackgroundGradientStops.WithValue(backgroundGradientStops)),
+                    Some [| Content.WithValue(content.Compile()) |],
+                    None
+                )
+            )

--- a/samples/Xamarin.Forms/TicTacToe/TicTacToe/TicTacToe.fsproj
+++ b/samples/Xamarin.Forms/TicTacToe/TicTacToe/TicTacToe.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Fabulous.Benchmarks/Benchmarks.fs
+++ b/src/Fabulous.Benchmarks/Benchmarks.fs
@@ -128,3 +128,15 @@ let main argv =
 //        ()
 //
 //    0 // return an integer exit code
+
+//[<EntryPoint>]
+//let mainProfile argv =
+//
+//    let b = DiffingAttributes.Benchmarks()
+//    b.depth <- 10
+//
+//    for _ in 0 .. 2 do
+//        let widgets = b.ProcessMessages()
+//        ()
+//
+//    0 // return an integer exit code

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -135,7 +135,7 @@ module SimpleStackTests =
     let init () = []
 
     [<Test>]
-    let SketchAPI () =
+    let Test () =
         let program =
             StatefulWidget.mkSimpleView init update view
 
@@ -159,7 +159,7 @@ module SimpleStackTests =
 
         // add second in front
         instance.ProcessMessage(AddNew(2, "yo2"))
-        Assert.AreEqual(stack.Children.Count, 2)
+        Assert.AreEqual(2, stack.Children.Count)
 
         let label =
             stack.Children.[0] :?> TestLabel :> IText
@@ -523,6 +523,7 @@ module MemoTests =
                         model
                         (fun _ ->
                             Label("one")
+                                .record(true)
                                 .textColor("blue")
                                 .automationId("label"))
                 | Label2 ->
@@ -530,6 +531,7 @@ module MemoTests =
                         (string model)
                         (fun _ ->
                             Label("two")
+                                .record(true)
                                 .textColor("blue")
                                 .automationId("label"))
             }

--- a/src/Fabulous.Tests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/TestUI.Attributes.fs
@@ -41,8 +41,12 @@ module Attributes =
     //    open Fabulous.Attributes
 
     module Text =
+        let Record =
+            Attributes.define<bool> "Text" TestUI_ViewUpdaters.updateRecord
+
         let Text =
             Attributes.define<string> "Text" TestUI_ViewUpdaters.updateText
+
 
     module TextStyle =
         let TextColor =

--- a/src/Fabulous.Tests/TestUI.Platform.fs
+++ b/src/Fabulous.Tests/TestUI.Platform.fs
@@ -30,6 +30,7 @@ type TestLabel() =
 
     let mutable text = ""
     let mutable textColor = ""
+    member val record = false with get, set
 
     member val changeList = [] with get, set
 
@@ -37,13 +38,17 @@ type TestLabel() =
         member x.Text
             with get () = text
             and set (value) =
-                x.changeList <- List.append x.changeList [ TextSet value ]
+                if x.record then
+                    x.changeList <- List.append x.changeList [ TextSet value ]
+
                 text <- value
 
         member x.TextColor
             with get () = textColor
             and set (value) =
-                x.changeList <- List.append x.changeList [ ColorSet value ]
+                if x.record then
+                    x.changeList <- List.append x.changeList [ ColorSet value ]
+
                 textColor <- value
 
 type TestStack() =

--- a/src/Fabulous.Tests/TestUI.ViewUpdaters.fs
+++ b/src/Fabulous.Tests/TestUI.ViewUpdaters.fs
@@ -41,6 +41,10 @@ let updateText (newValueOpt: string voption, viewNode: IViewNode) =
     let textElement = viewNode.Target :?> IText
     textElement.Text <- ValueOption.defaultValue "" newValueOpt
 
+let updateRecord (newValueOpt: bool voption, viewNode: IViewNode) =
+    let textElement = viewNode.Target :?> TestLabel
+    textElement.record <- ValueOption.defaultValue false newValueOpt
+
 let updateTextColor (newValueOpt: string voption, viewNode: IViewNode) =
     let textElement = viewNode.Target :?> IText
     textElement.TextColor <- ValueOption.defaultValue "" newValueOpt

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -3,6 +3,7 @@ module Tests.TestUI_Widgets
 open System
 open System.Runtime.CompilerServices
 open Fabulous
+open Fabulous.StackAllocatedCollections
 open Tests
 open Tests.Platform
 open TestUI_Attributes
@@ -37,10 +38,12 @@ module Widgets =
 
                         view.PropertyBag.Add(ViewNode.ViewNodeProperty, viewNode)
 
+                        let oldWidget: Widget voption = ValueNone
+
                         Reconciler.update
                             //                            context.ViewTreeContext.GetViewNode
                             context.CanReuseView
-                            ValueNone
+                            oldWidget
                             widget
                             viewNode
 
@@ -92,10 +95,16 @@ type WidgetExtensions() =
         this.AddScalar(Attributes.TextStyle.TextColor.WithValue(value))
 
 
-let inline private scalars
-    (value: ScalarAttribute [])
-    : struct (ScalarAttribute [] * WidgetAttribute [] * WidgetCollectionAttribute []) =
-    struct (value, [||], [||])
+    [<Extension>]
+    static member inline record<'msg, 'marker when 'marker :> TestLabelMarker>
+        (
+            this: WidgetBuilder<'msg, 'marker>,
+            value: bool
+        ) =
+        this.AddScalar(Attributes.Text.Record.WithValue(value))
+
+
+let inline private scalars (value: StackArray3<ScalarAttribute>) : AttributesInFlight = struct (value, None, None)
 
 ///----------------
 
@@ -106,18 +115,28 @@ type View private () =
     static let TestStackKey = Widgets.register<TestStack>()
 
     static member Label<'msg>(text: string) =
-        WidgetBuilder<'msg, TestLabelMarker>(TestLabelKey, scalars [| Attributes.Text.Text.WithValue(text) |])
+        WidgetBuilder<'msg, TestLabelMarker>(
+            TestLabelKey,
+            scalars(StackArray3.one(Attributes.Text.Text.WithValue(text)))
+        )
 
 
     static member Button<'msg>(text: string, onClicked: 'msg) =
         WidgetBuilder<'msg, TestButtonMarker>(
             TestButtonKey,
-            scalars [| Attributes.Text.Text.WithValue(text)
-                       Attributes.Button.Pressed.WithValue(onClicked) |]
+            scalars(
+                StackArray3.two(Attributes.Text.Text.WithValue(text), Attributes.Button.Pressed.WithValue(onClicked))
+            )
+        //            scalars [| Attributes.Text.Text.WithValue(text)
+//                       Attributes.Button.Pressed.WithValue(onClicked) |]
         )
 
     static member Stack<'msg, 'marker when 'marker :> IMarker>() =
-        CollectionBuilder<'msg, TestStackMarker, 'marker>(TestStackKey, ValueNone, Attributes.Container.Children)
+        CollectionBuilder<'msg, TestStackMarker, 'marker>(
+            TestStackKey,
+            StackArray3.empty(),
+            Attributes.Container.Children
+        )
 
 [<Extension>]
 type CollectionBuilderExtensions =
@@ -127,7 +146,9 @@ type CollectionBuilderExtensions =
             _: CollectionBuilder<'msg, 'marker, IMarker>,
             x: WidgetBuilder<'msg, 'itemMarker>
         ) : Content<'msg> =
-        { Widgets = [ x.Compile() ] }
+        {
+            Widgets = StackArray3.one(x.Compile())
+        }
 
     [<Extension>]
     static member inline Yield<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
@@ -135,7 +156,9 @@ type CollectionBuilderExtensions =
             _: CollectionBuilder<'msg, 'marker, IMarker>,
             x: WidgetBuilder<'msg, Memo.Memoized<'itemMarker>>
         ) : Content<'msg> =
-        { Widgets = [ x.Compile() ] }
+        {
+            Widgets = StackArray3.one(x.Compile())
+        }
 
     [<Extension>]
     static member inline YieldFrom<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
@@ -144,7 +167,11 @@ type CollectionBuilderExtensions =
             x: WidgetBuilder<'msg, 'itemMarker> seq
         ) : Content<'msg> =
         {
-            Widgets = x |> Seq.map(fun wb -> wb.Compile()) |> Seq.toList
+            Widgets =
+                x
+                |> Seq.map(fun wb -> wb.Compile())
+                |> Seq.toArray
+                |> StackArray3.many
         }
 
 
@@ -199,7 +226,8 @@ module Run =
                 state <- Some(newModel, target, newWidget)
 
                 // ViewNode.getViewNode
-                Reconciler.update x.viewContext.CanReuseView (ValueSome oldWidget) newWidget viewNode
+                let oldWidget = (ValueSome oldWidget)
+                Reconciler.update x.viewContext.CanReuseView oldWidget newWidget viewNode
                 ()
 
         member x.Start(arg: 'arg) =

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -154,7 +154,7 @@ type CollectionBuilderExtensions =
         }
 
     [<Extension>]
-    static member YieldFrom<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
+    static member inline YieldFrom<'msg, 'marker, 'itemMarker when 'itemMarker :> IMarker>
         (
             _: CollectionBuilder<'msg, 'marker, IMarker>,
             x: WidgetBuilder<'msg, 'itemMarker> seq

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -4,6 +4,7 @@ open System
 open System.Runtime.CompilerServices
 open Fabulous
 open Fabulous.StackAllocatedCollections
+open Fabulous.StackAllocatedCollections.StackList
 open Tests
 open Tests.Platform
 open TestUI_Attributes
@@ -126,7 +127,7 @@ type View private () =
     static member Stack<'msg, 'marker when 'marker :> IMarker>() =
         CollectionBuilder<'msg, TestStackMarker, 'marker>(
             TestStackKey,
-            StackArray3.empty(),
+            StackList.empty(),
             Attributes.Container.Children
         )
 

--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Fabulous.XamarinForms/ViewUpdaters.fs
+++ b/src/Fabulous.XamarinForms/ViewUpdaters.fs
@@ -110,15 +110,15 @@ module ViewUpdaters =
                 let childNode = node.GetViewNodeForChild(pages.[index])
 
                 match diff.ScalarChanges with
-                | Some changes -> childNode.ApplyScalarDiffs(changes)
-                | None -> ()
+                | ValueSome changes -> childNode.ApplyScalarDiffs(changes)
+                | ValueNone -> ()
 
                 match diff.WidgetChanges with
-                | ValueSome slice -> childNode.ApplyWidgetDiffs slice
+                | ValueSome slice -> childNode.ApplyWidgetDiffs(ArraySlice.toSpan slice)
                 | ValueNone -> ()
 
                 match diff.WidgetCollectionChanges with
-                | ValueSome slice -> childNode.ApplyWidgetCollectionDiffs slice
+                | ValueSome slice -> childNode.ApplyWidgetCollectionDiffs(ArraySlice.toSpan slice)
                 | ValueNone -> ()
 
 

--- a/src/Fabulous.XamarinForms/ViewUpdaters.fs
+++ b/src/Fabulous.XamarinForms/ViewUpdaters.fs
@@ -107,7 +107,7 @@ module ViewUpdaters =
                         |> ignore
 
             | WidgetCollectionItemChange.Update (index, diff) ->
-                let childNode = node.TrreContext.GetViewNode(pages.[index])
+                let childNode = node.TreeContext.GetViewNode(pages.[index])
 
                 match diff.ScalarChanges with
                 | ValueSome changes -> childNode.ApplyScalarDiffs(changes)

--- a/src/Fabulous.XamarinForms/ViewUpdaters.fs
+++ b/src/Fabulous.XamarinForms/ViewUpdaters.fs
@@ -6,12 +6,15 @@ open Xamarin.Forms
 module ViewUpdaters =
     let updateSliderMinMax (newValueOpt: (float * float) voption, node: IViewNode) =
         let slider = node.Target :?> Slider
+
         match newValueOpt with
         | ValueNone ->
             slider.ClearValue(Slider.MinimumProperty)
             slider.ClearValue(Slider.MaximumProperty)
         | ValueSome (min, max) ->
-            let currMax = slider.GetValue(Slider.MaximumProperty) :?> float
+            let currMax =
+                slider.GetValue(Slider.MaximumProperty) :?> float
+
             if min > currMax then
                 slider.SetValue(Slider.MaximumProperty, max)
                 slider.SetValue(Slider.MinimumProperty, min)
@@ -21,12 +24,15 @@ module ViewUpdaters =
 
     let updateStepperMinMax (newValueOpt: (float * float) voption, node: IViewNode) =
         let stepper = node.Target :?> Stepper
+
         match newValueOpt with
         | ValueNone ->
             stepper.ClearValue(Stepper.MinimumProperty)
             stepper.ClearValue(Stepper.MaximumProperty)
         | ValueSome (min, max) ->
-            let currMax = stepper.GetValue(Stepper.MaximumProperty) :?> float
+            let currMax =
+                stepper.GetValue(Stepper.MaximumProperty) :?> float
+
             if min > currMax then
                 stepper.SetValue(Stepper.MaximumProperty, max)
                 stepper.SetValue(Stepper.MinimumProperty, min)
@@ -34,8 +40,9 @@ module ViewUpdaters =
                 stepper.SetValue(Stepper.MinimumProperty, min)
                 stepper.SetValue(Stepper.MaximumProperty, max)
 
-    let updateGridColumnDefinitions (newValueOpt: Dimension[] voption, node: IViewNode) =
+    let updateGridColumnDefinitions (newValueOpt: Dimension [] voption, node: IViewNode) =
         let grid = node.Target :?> Grid
+
         match newValueOpt with
         | ValueNone -> grid.ColumnDefinitions.Clear()
         | ValueSome coll ->
@@ -51,8 +58,9 @@ module ViewUpdaters =
 
                 grid.ColumnDefinitions.Add(ColumnDefinition(Width = gridLength))
 
-    let updateGridRowDefinitions (newValueOpt: Dimension[] voption, node: IViewNode) =
+    let updateGridRowDefinitions (newValueOpt: Dimension [] voption, node: IViewNode) =
         let grid = node.Target :?> Grid
+
         match newValueOpt with
         | ValueNone -> grid.RowDefinitions.Clear()
         | ValueSome coll ->
@@ -70,75 +78,99 @@ module ViewUpdaters =
 
     /// NOTE: Would be better to have a custom diff logic for Navigation
     /// because it's a Stack and not a random access collection
-    let applyDiffNavigationPagePages (diffs: WidgetCollectionItemChange[], node: IViewNode) =
+    let applyDiffNavigationPagePages (diffs: ArraySlice<WidgetCollectionItemChange>, node: IViewNode) =
         let navigationPage = node.Target :?> NavigationPage
         let pages = List.ofSeq navigationPage.Pages
 
-        for diff in diffs do
+        for diff in ArraySlice.toSpan diffs do
             match diff with
             | WidgetCollectionItemChange.Insert (index, widget) ->
                 if index >= pages.Length then
-                    let page = Helpers.createViewForWidget node widget :?> Page
+                    let page =
+                        Helpers.createViewForWidget node widget :?> Page
+
                     navigationPage.PushAsync(page) |> ignore
                 else
                     let temp = System.Collections.Generic.Stack<Page>()
-                    
+
                     for i = pages.Length - 1 to index do
                         temp.Push(pages.[i])
                         navigationPage.PopAsync() |> ignore
-                    
-                    let page = Helpers.createViewForWidget node widget :?> Page
+
+                    let page =
+                        Helpers.createViewForWidget node widget :?> Page
+
                     navigationPage.PushAsync(page, false) |> ignore
-                    
-                    while temp.Count > 0  do
-                        navigationPage.PushAsync(temp.Pop(), false) |> ignore
-                        
+
+                    while temp.Count > 0 do
+                        navigationPage.PushAsync(temp.Pop(), false)
+                        |> ignore
+
             | WidgetCollectionItemChange.Update (index, diff) ->
-                let childNode = node.GetViewNodeForChild(pages[index])
-                if diff.ScalarChanges.Length > 0 then childNode.ApplyScalarDiffs(diff.ScalarChanges)
-                if diff.WidgetChanges.Length > 0 then childNode.ApplyWidgetDiffs(diff.WidgetChanges)
-                if diff.WidgetCollectionChanges.Length > 0 then childNode.ApplyWidgetCollectionDiffs(diff.WidgetCollectionChanges)
+                let childNode = node.GetViewNodeForChild(pages.[index])
+
+                match diff.ScalarChanges with
+                | Some changes -> childNode.ApplyScalarDiffs(changes)
+                | None -> ()
+
+                match diff.WidgetChanges with
+                | ValueSome slice -> childNode.ApplyWidgetDiffs slice
+                | ValueNone -> ()
+
+                match diff.WidgetCollectionChanges with
+                | ValueSome slice -> childNode.ApplyWidgetCollectionDiffs slice
+                | ValueNone -> ()
+
 
             | WidgetCollectionItemChange.Replace (index, widget) ->
                 if index = pages.Length - 1 then
                     navigationPage.PopAsync() |> ignore
-                    let page = Helpers.createViewForWidget node widget :?> Page
+
+                    let page =
+                        Helpers.createViewForWidget node widget :?> Page
+
                     navigationPage.PushAsync(page) |> ignore
                 else
                     let temp = System.Collections.Generic.Stack<Page>()
-                    
+
                     for i = pages.Length - 1 to index do
                         temp.Push(pages.[i])
                         navigationPage.PopAsync() |> ignore
-                    
-                    let page = Helpers.createViewForWidget node widget :?> Page
+
+                    let page =
+                        Helpers.createViewForWidget node widget :?> Page
+
                     navigationPage.PushAsync(page, false) |> ignore
-                    
+
                     while temp.Count > 1 do
-                        navigationPage.PushAsync(temp.Pop(), false) |> ignore
-                        
+                        navigationPage.PushAsync(temp.Pop(), false)
+                        |> ignore
+
             | WidgetCollectionItemChange.Remove index ->
                 if index > pages.Length - 1 then
                     () // Do nothing, page has already been popped
                 elif index = pages.Length - 1 then
-                   navigationPage.PopAsync() |> ignore
+                    navigationPage.PopAsync() |> ignore
                 else
                     let temp = System.Collections.Generic.Stack<Page>()
-                    
+
                     for i = pages.Length - 1 to index do
                         temp.Push(pages.[i])
                         navigationPage.PopAsync() |> ignore
-                    
-                    while temp.Count > 1 do
-                        navigationPage.PushAsync(temp.Pop(), false) |> ignore
 
-    let updateNavigationPagePages (newValueOpt: Widget[] voption, node: IViewNode) =
+                    while temp.Count > 1 do
+                        navigationPage.PushAsync(temp.Pop(), false)
+                        |> ignore
+
+    let updateNavigationPagePages (newValueOpt: ArraySlice<Widget> voption, node: IViewNode) =
         let navigationPage = node.Target :?> NavigationPage
         navigationPage.PopToRootAsync(false) |> ignore
 
         match newValueOpt with
         | ValueNone -> ()
         | ValueSome widgets ->
-            for widget in widgets do
-                let page = Helpers.createViewForWidget node widget :?> Page
+            for widget in ArraySlice.toSpan widgets do
+                let page =
+                    Helpers.createViewForWidget node widget :?> Page
+
                 navigationPage.PushAsync(page) |> ignore

--- a/src/Fabulous.XamarinForms/WidgetExtensions.fs
+++ b/src/Fabulous.XamarinForms/WidgetExtensions.fs
@@ -1,5 +1,6 @@
 ﻿namespace Fabulous.XamarinForms
 
+open Fabulous.StackAllocatedCollections
 open Xamarin.Forms
 open Xamarin.Forms.PlatformConfiguration
 open Xamarin.Forms.PlatformConfiguration.iOSSpecific
@@ -11,74 +12,128 @@ open Fabulous.XamarinForms.XFAttributes
 
 module AdditionalAttributes =
     module iOS =
-        let UseSafeArea = Attributes.define<bool> "Page_UseSafeArea" (fun (newValueOpt, node) ->
-            let page = node.Target :?> Xamarin.Forms.Page
-            let value = 
-                match newValueOpt with
-                | ValueNone -> false
-                | ValueSome v -> v
+        let UseSafeArea =
+            Attributes.define<bool>
+                "Page_UseSafeArea"
+                (fun (newValueOpt, node) ->
+                    let page = node.Target :?> Xamarin.Forms.Page
 
-            page.On<iOS>().SetUseSafeArea(value) |> ignore
-        )
+                    let value =
+                        match newValueOpt with
+                        | ValueNone -> false
+                        | ValueSome v -> v
+
+                    page.On<iOS>().SetUseSafeArea(value) |> ignore)
 
     module Android =
-        let ToolbarPlacement = Attributes.define<ToolbarPlacement> "TabbedPage_ToolbarPlacement" (fun (newValueOpt, node) ->
-            let tabbedPage = node.Target :?> Xamarin.Forms.TabbedPage
-            let value =
-                match newValueOpt with
-                | ValueNone -> ToolbarPlacement.Default
-                | ValueSome v -> v
-            tabbedPage.On<Android>().SetToolbarPlacement(value) |> ignore
-        )
+        let ToolbarPlacement =
+            Attributes.define<ToolbarPlacement>
+                "TabbedPage_ToolbarPlacement"
+                (fun (newValueOpt, node) ->
+                    let tabbedPage = node.Target :?> Xamarin.Forms.TabbedPage
+
+                    let value =
+                        match newValueOpt with
+                        | ValueNone -> ToolbarPlacement.Default
+                        | ValueSome v -> v
+
+                    tabbedPage
+                        .On<Android>()
+                        .SetToolbarPlacement(value)
+                    |> ignore)
 
 [<Extension>]
 type AdditionalViewExtensions =
     [<Extension>]
     static member inline center(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.Center | Some true -> LayoutOptions.CenterAndExpand
-        this.AddScalars([|
-            View.HorizontalOptions.WithValue(options)
-            View.VerticalOptions.WithValue(options)
-        |])
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.Center
+            | Some true -> LayoutOptions.CenterAndExpand
+
+        this.AddScalars(
+            StackArray3.two(View.HorizontalOptions.WithValue(options), View.VerticalOptions.WithValue(options))
+        )
 
     [<Extension>]
     static member inline centerHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.Center | Some true -> LayoutOptions.CenterAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.Center
+            | Some true -> LayoutOptions.CenterAndExpand
+
         this.AddScalar(View.HorizontalOptions.WithValue(options))
 
     [<Extension>]
     static member inline centerVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.Center | Some true -> LayoutOptions.CenterAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.Center
+            | Some true -> LayoutOptions.CenterAndExpand
+
         this.AddScalar(View.VerticalOptions.WithValue(options))
-        
+
     [<Extension>]
     static member inline alignStartHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.Start | Some true -> LayoutOptions.StartAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.Start
+            | Some true -> LayoutOptions.StartAndExpand
+
         this.AddScalar(View.HorizontalOptions.WithValue(options))
-        
+
     [<Extension>]
     static member inline alignStartVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.Start | Some true -> LayoutOptions.StartAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.Start
+            | Some true -> LayoutOptions.StartAndExpand
+
         this.AddScalar(View.VerticalOptions.WithValue(options))
-        
+
     [<Extension>]
     static member inline alignEndHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.End | Some true -> LayoutOptions.EndAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.End
+            | Some true -> LayoutOptions.EndAndExpand
+
         this.AddScalar(View.HorizontalOptions.WithValue(options))
-        
+
     [<Extension>]
     static member inline alignEndVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.End | Some true -> LayoutOptions.EndAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.End
+            | Some true -> LayoutOptions.EndAndExpand
+
         this.AddScalar(View.VerticalOptions.WithValue(options))
-        
+
     [<Extension>]
     static member inline fillHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.Fill | Some true -> LayoutOptions.FillAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.Fill
+            | Some true -> LayoutOptions.FillAndExpand
+
         this.AddScalar(View.HorizontalOptions.WithValue(options))
-        
+
     [<Extension>]
     static member inline fillVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
-        let options = match expand with None | Some false -> LayoutOptions.Fill | Some true -> LayoutOptions.FillAndExpand
+        let options =
+            match expand with
+            | None
+            | Some false -> LayoutOptions.Fill
+            | Some true -> LayoutOptions.FillAndExpand
+
         this.AddScalar(View.VerticalOptions.WithValue(options))
 
     [<Extension>]
@@ -92,31 +147,88 @@ type AdditionalViewExtensions =
     [<Extension>]
     static member inline centerTextVertical(this: WidgetBuilder<_, #ILabel>) =
         this.AddScalar(Label.VerticalTextAlignment.WithValue(TextAlignment.Center))
-        
-    [<Extension>]
-    static member inline font(this: WidgetBuilder<'msg, ILabel>, ?size: double, ?namedSize: NamedSize, ?attributes: FontAttributes) =
-        this.AddScalars([|
-            match size with None -> () | Some v -> Label.FontSize.WithValue(v)
-            match namedSize with None -> () | Some v -> Label.FontSize.WithValue(Device.GetNamedSize(v, typeof<Label>))
-            match attributes with None -> () | Some v -> Label.FontAttributes.WithValue(v)
-        |])
 
     [<Extension>]
-    static member inline font(this: WidgetBuilder<'msg, IDatePicker>, ?size: double, ?namedSize: NamedSize, ?attributes: FontAttributes) =
-        this.AddScalars([|
-            match size with None -> () | Some v -> DatePicker.FontSize.WithValue(v)
-            match namedSize with None -> () | Some v -> DatePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<DatePicker>))
-            match attributes with None -> () | Some v -> DatePicker.FontAttributes.WithValue(v)
-        |])
+    static member inline font
+        (
+            this: WidgetBuilder<'msg, ILabel>,
+            ?size: double,
+            ?namedSize: NamedSize,
+            ?attributes: FontAttributes
+        ) =
+
+        let mutable res = StackArray3.empty()
+
+        match size with
+        | None -> ()
+        | Some v -> res <- StackArray3.add(&res, Label.FontSize.WithValue(v))
+
+        match namedSize with
+        | None -> ()
+        | Some v -> res <- StackArray3.add(&res, Label.FontSize.WithValue(Device.GetNamedSize(v, typeof<Label>)))
+
+        match attributes with
+        | None -> ()
+        | Some v -> res <- StackArray3.add(&res, Label.FontAttributes.WithValue(v))
+
+
+        this.AddScalars(res)
 
     [<Extension>]
-    static member inline font(this: WidgetBuilder<'msg, ITimePicker>, ?size: double, ?namedSize: NamedSize, ?attributes: FontAttributes) =
-        this.AddScalars([|
-            match size with None -> () | Some v -> TimePicker.FontSize.WithValue(v)
-            match namedSize with None -> () | Some v -> TimePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<TimePicker>))
-            match attributes with None -> () | Some v -> TimePicker.FontAttributes.WithValue(v)
-        |])
-        
+    static member inline font
+        (
+            this: WidgetBuilder<'msg, IDatePicker>,
+            ?size: double,
+            ?namedSize: NamedSize,
+            ?attributes: FontAttributes
+        ) =
+
+        let mutable res = StackArray3.empty()
+
+        match size with
+        | None -> ()
+        | Some v -> res <- StackArray3.add(&res, DatePicker.FontSize.WithValue(v))
+
+        match namedSize with
+        | None -> ()
+        | Some v ->
+            res <- StackArray3.add(&res, DatePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<DatePicker>)))
+
+        match attributes with
+        | None -> ()
+        | Some v -> res <- StackArray3.add(&res, DatePicker.FontAttributes.WithValue(v))
+
+        this.AddScalars(res)
+
+
+
+    [<Extension>]
+    static member inline font
+        (
+            this: WidgetBuilder<'msg, ITimePicker>,
+            ?size: double,
+            ?namedSize: NamedSize,
+            ?attributes: FontAttributes
+        ) =
+
+        let mutable res = StackArray3.empty()
+
+        match size with
+        | None -> ()
+        | Some v -> res <- StackArray3.add(&res, TimePicker.FontSize.WithValue(v))
+
+        match namedSize with
+        | None -> ()
+        | Some v ->
+            res <- StackArray3.add(&res, TimePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<TimePicker>)))
+
+        match attributes with
+        | None -> ()
+        | Some v -> res <- StackArray3.add(&res, TimePicker.FontAttributes.WithValue(v))
+
+        this.AddScalars(res)
+
+
     [<Extension>]
     static member inline font(this: WidgetBuilder<'msg, IButton>, value: NamedSize) =
         this.AddScalar(Button.FontSize.WithValue(Device.GetNamedSize(value, typeof<Xamarin.Forms.Button>)))
@@ -148,30 +260,46 @@ type AdditionalViewExtensions =
     [<Extension>]
     static member inline ignoreSafeArea(this: WidgetBuilder<_, #IPage>) =
         this.AddScalar(AdditionalAttributes.iOS.UseSafeArea.WithValue(false))
-        
+
     [<Extension>]
     static member inline androidToolbarPlacement(this: WidgetBuilder<_, #ITabbedPage>, value: ToolbarPlacement) =
         this.AddScalar(AdditionalAttributes.Android.ToolbarPlacement.WithValue(value))
-        
+
     [<Extension>]
     static member inline margin(this: WidgetBuilder<'msg, #IView>, value: float) =
         this.AddScalar(View.Margin.WithValue(Thickness(value)))
-        
+
     [<Extension>]
-    static member size(this: WidgetBuilder<'msg, #IView>, ?width: float, ?height: float) =
-        this.AddScalars([|
-            match width with None -> () | Some v -> VisualElement.Width.WithValue(v)
-            match height with None -> () | Some v -> VisualElement.Height.WithValue(v)
-        |])
-    
+    static member inline size(this: WidgetBuilder<'msg, #IView>, ?width: float, ?height: float) =
+        match width, height with
+        | None, None -> this
+        | Some w, None -> this.AddScalar(VisualElement.Width.WithValue(w))
+        | None, Some h -> this.AddScalar(VisualElement.Height.WithValue(h))
+        | Some w, Some h ->
+            this.AddScalars(StackArray3.two(VisualElement.Width.WithValue(w), VisualElement.Height.WithValue(h)))
+
     [<Extension>]
     static member inline padding(this: WidgetBuilder<_, #IView>, left: float, top: float, right: float, bottom: float) =
         this.AddScalar(Label.Padding.WithValue(Thickness(left, top, right, bottom)))
-        
+
     [<Extension>]
-    static member inline margin(this: WidgetBuilder<'msg, #IView>, left: float, top: float, right: float, bottom: float) =
+    static member inline margin
+        (
+            this: WidgetBuilder<'msg, #IView>,
+            left: float,
+            top: float,
+            right: float,
+            bottom: float
+        ) =
         this.AddScalar(View.Margin.WithValue(Thickness(left, top, right, bottom)))
 
     [<Extension>]
-    static member inline paddingLayout(this: WidgetBuilder<_, #ILayout>, left: float, top: float, right: float, bottom: float) =
+    static member inline paddingLayout
+        (
+            this: WidgetBuilder<_, #ILayout>,
+            left: float,
+            top: float,
+            right: float,
+            bottom: float
+        ) =
         this.AddScalar(Layout.Padding.WithValue(Thickness(left, top, right, bottom)))

--- a/src/Fabulous.XamarinForms/WidgetExtensions.fs
+++ b/src/Fabulous.XamarinForms/WidgetExtensions.fs
@@ -1,6 +1,5 @@
 ﻿namespace Fabulous.XamarinForms
 
-open Fabulous.StackAllocatedCollections
 open Xamarin.Forms
 open Xamarin.Forms.PlatformConfiguration
 open Xamarin.Forms.PlatformConfiguration.iOSSpecific
@@ -52,9 +51,10 @@ type AdditionalViewExtensions =
             | Some false -> LayoutOptions.Center
             | Some true -> LayoutOptions.CenterAndExpand
 
-        this.AddScalars(
-            StackArray3.two(View.HorizontalOptions.WithValue(options), View.VerticalOptions.WithValue(options))
-        )
+        this
+            .AddScalar(View.HorizontalOptions.WithValue(options))
+            .AddScalar(View.VerticalOptions.WithValue(options))
+
 
     [<Extension>]
     static member inline centerHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -157,22 +157,21 @@ type AdditionalViewExtensions =
             ?attributes: FontAttributes
         ) =
 
-        let mutable res = StackArray3.empty()
+        let mutable res = this
 
         match size with
         | None -> ()
-        | Some v -> res <- StackArray3.add(&res, Label.FontSize.WithValue(v))
+        | Some v -> res <- res.AddScalar(Label.FontSize.WithValue(v))
 
         match namedSize with
         | None -> ()
-        | Some v -> res <- StackArray3.add(&res, Label.FontSize.WithValue(Device.GetNamedSize(v, typeof<Label>)))
+        | Some v -> res <- res.AddScalar(Label.FontSize.WithValue(Device.GetNamedSize(v, typeof<Label>)))
 
         match attributes with
         | None -> ()
-        | Some v -> res <- StackArray3.add(&res, Label.FontAttributes.WithValue(v))
+        | Some v -> res <- res.AddScalar(Label.FontAttributes.WithValue(v))
 
-
-        this.AddScalars(res)
+        res
 
     [<Extension>]
     static member inline font
@@ -183,22 +182,21 @@ type AdditionalViewExtensions =
             ?attributes: FontAttributes
         ) =
 
-        let mutable res = StackArray3.empty()
+        let mutable res = this
 
         match size with
         | None -> ()
-        | Some v -> res <- StackArray3.add(&res, DatePicker.FontSize.WithValue(v))
+        | Some v -> res <- res.AddScalar(DatePicker.FontSize.WithValue(v))
 
         match namedSize with
         | None -> ()
-        | Some v ->
-            res <- StackArray3.add(&res, DatePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<DatePicker>)))
+        | Some v -> res <- res.AddScalar(DatePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<DatePicker>)))
 
         match attributes with
         | None -> ()
-        | Some v -> res <- StackArray3.add(&res, DatePicker.FontAttributes.WithValue(v))
+        | Some v -> res <- res.AddScalar(DatePicker.FontAttributes.WithValue(v))
 
-        this.AddScalars(res)
+        res
 
 
 
@@ -211,22 +209,21 @@ type AdditionalViewExtensions =
             ?attributes: FontAttributes
         ) =
 
-        let mutable res = StackArray3.empty()
+        let mutable res = this
 
         match size with
         | None -> ()
-        | Some v -> res <- StackArray3.add(&res, TimePicker.FontSize.WithValue(v))
+        | Some v -> res <- res.AddScalar(TimePicker.FontSize.WithValue(v))
 
         match namedSize with
         | None -> ()
-        | Some v ->
-            res <- StackArray3.add(&res, TimePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<TimePicker>)))
+        | Some v -> res <- res.AddScalar(TimePicker.FontSize.WithValue(Device.GetNamedSize(v, typeof<TimePicker>)))
 
         match attributes with
         | None -> ()
-        | Some v -> res <- StackArray3.add(&res, TimePicker.FontAttributes.WithValue(v))
+        | Some v -> res <- res.AddScalar(TimePicker.FontAttributes.WithValue(v))
 
-        this.AddScalars(res)
+        res
 
 
     [<Extension>]
@@ -276,7 +273,9 @@ type AdditionalViewExtensions =
         | Some w, None -> this.AddScalar(VisualElement.Width.WithValue(w))
         | None, Some h -> this.AddScalar(VisualElement.Height.WithValue(h))
         | Some w, Some h ->
-            this.AddScalars(StackArray3.two(VisualElement.Width.WithValue(w), VisualElement.Height.WithValue(h)))
+            this
+                .AddScalar(VisualElement.Width.WithValue(w))
+                .AddScalar(VisualElement.Height.WithValue(h))
 
     [<Extension>]
     static member inline padding(this: WidgetBuilder<_, #IView>, left: float, top: float, right: float, bottom: float) =

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -3,6 +3,7 @@
 open System
 open System.Runtime.CompilerServices
 open Fabulous
+open Fabulous.StackAllocatedCollections.StackList
 open Fabulous.StackAllocatedCollections
 open Fabulous.XamarinForms
 
@@ -111,7 +112,7 @@ module ViewHelpers =
         |> Seq.toArray
 
     let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute []) =
-        WidgetBuilder<'msg, 'marker>(key, struct (StackArray3.empty(), Some attrs, None))
+        WidgetBuilder<'msg, 'marker>(key, struct (StackList.empty(), Some attrs, None))
 
     let inline buildAttributeCollection<'msg, 'marker, 'item>
         (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -87,6 +87,21 @@ type CollectionBuilderExtensions =
         {
             Widgets = MutStackArray1.One(x.Compile())
         }
+        
+    
+        
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IPage>(_: CollectionBuilder<'msg, 'marker, IPage>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IView>(_: CollectionBuilder<'msg, 'marker, IView>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>(_: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>(_: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>, x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }
 
 module ViewHelpers =
     let inline compileSeq (items: seq<WidgetBuilder<'msg, #IMarker>>) =

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -3,6 +3,7 @@
 open System
 open System.Runtime.CompilerServices
 open Fabulous
+open Fabulous.StackAllocatedCollections
 open Fabulous.XamarinForms
 
 type IMarker =
@@ -69,7 +70,9 @@ type CollectionBuilderExtensions =
             _: CollectionBuilder<'msg, 'marker, IPage>,
             x: WidgetBuilder<'msg, 'itemType>
         ) : Content<'msg> =
-        { Widgets = [ x.Compile() ] }
+        {
+            Widgets = MutStackArray1.One(x.Compile())
+        }
 
     [<Extension>]
     static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IView>
@@ -77,7 +80,9 @@ type CollectionBuilderExtensions =
             _: CollectionBuilder<'msg, 'marker, IView>,
             x: WidgetBuilder<'msg, 'itemType>
         ) : Content<'msg> =
-        { Widgets = [ x.Compile() ] }
+        {
+            Widgets = MutStackArray1.One(x.Compile())
+        }
 
     [<Extension>]
     static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>
@@ -85,7 +90,9 @@ type CollectionBuilderExtensions =
             _: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>,
             x: WidgetBuilder<'msg, 'itemType>
         ) : Content<'msg> =
-        { Widgets = [ x.Compile() ] }
+        {
+            Widgets = MutStackArray1.One(x.Compile())
+        }
 
     [<Extension>]
     static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>
@@ -93,7 +100,9 @@ type CollectionBuilderExtensions =
             _: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>,
             x: WidgetBuilder<'msg, 'itemType>
         ) : Content<'msg> =
-        { Widgets = [ x.Compile() ] }
+        {
+            Widgets = MutStackArray1.One(x.Compile())
+        }
 
 module ViewHelpers =
     let inline compileSeq (items: seq<WidgetBuilder<'msg, #IMarker>>) =
@@ -101,32 +110,8 @@ module ViewHelpers =
         |> Seq.map(fun item -> item.Compile())
         |> Seq.toArray
 
-    let inline buildScalars<'msg, 'marker> (key: WidgetKey) (attrs: ScalarAttribute []) =
-        WidgetBuilder<'msg, 'marker>(key, struct (attrs, [||], [||]))
-
     let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute []) =
-        WidgetBuilder<'msg, 'marker>(key, struct ([||], attrs, [||]))
-
-    let inline build<'msg, 'marker>
-        (key: WidgetKey)
-        (scalars: ScalarAttribute [])
-        (widgets: WidgetAttribute [])
-        (widgetColls: WidgetCollectionAttribute [])
-        =
-        WidgetBuilder<'msg, 'marker>(key, struct (scalars, widgets, widgetColls))
-
-    let inline buildCollectionNoScalar<'msg, 'marker, 'item>
-        (key: WidgetKey)
-        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
-        =
-        CollectionBuilder<'msg, 'marker, 'item>(key, ValueNone, collectionAttributeDefinition)
-
-    let inline buildCollection<'msg, 'marker, 'item>
-        (key: WidgetKey)
-        (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
-        (scalars: ScalarAttribute [])
-        =
-        CollectionBuilder<'msg, 'marker, 'item>(key, ValueSome scalars, collectionAttributeDefinition)
+        WidgetBuilder<'msg, 'marker>(key, struct (StackArray3.empty(), Some attrs, None))
 
     let inline buildAttributeCollection<'msg, 'marker, 'item>
         (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -112,7 +112,7 @@ module ViewHelpers =
         |> Seq.toArray
 
     let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute []) =
-        WidgetBuilder<'msg, 'marker>(key, struct (StackList.empty(), Some attrs, None))
+        WidgetBuilder<'msg, 'marker>(key, struct (StackList.empty(), ValueSome attrs, ValueNone))
 
     let inline buildAttributeCollection<'msg, 'marker, 'item>
         (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)

--- a/src/Fabulous.XamarinForms/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.XamarinForms/Xamarin.Forms.Core.fs
@@ -1,446 +1,802 @@
 namespace Fabulous.XamarinForms
 
 open Fabulous
+open Fabulous.StackAllocatedCollections
 open Fabulous.XamarinForms
 open Fabulous.XamarinForms.XFAttributes
 open System.Runtime.CompilerServices
 open System
 open System.IO
 open Microsoft.FSharp.Core
-    
-type IContentPage = inherit IPage
-type IStackLayout = inherit ILayout
-type IGrid = inherit ILayout
-type ILabel = inherit IView
-type IButton = inherit IView
-type ISwitch = inherit IView
-type ISlider = inherit IView
-type IActivityIndicator = inherit IView
-type IContentView = inherit ILayout
-type IRefreshView = inherit IView
-type IScrollView = inherit IView
-type IImage = inherit IView
-type IBoxView = inherit IView
-type INavigationPage = inherit IPage
-type IEntry = inherit IView
-type ITapGestureRecognizer = inherit IGestureRecognizer
-type ISearchBar = inherit IView
-type IEditor = inherit IView
-type IViewCell = inherit ICell
-type IImageButton = inherit IView
-type ITabbedPage = inherit IPage
-type IDatePicker = inherit IView
-type ITimePicker = inherit IView
-type IStepper = inherit IView
-        
+
+type IContentPage =
+    inherit IPage
+
+type IStackLayout =
+    inherit ILayout
+
+type IGrid =
+    inherit ILayout
+
+type ILabel =
+    inherit IView
+
+type IButton =
+    inherit IView
+
+type ISwitch =
+    inherit IView
+
+type ISlider =
+    inherit IView
+
+type IActivityIndicator =
+    inherit IView
+
+type IContentView =
+    inherit ILayout
+
+type IRefreshView =
+    inherit IView
+
+type IScrollView =
+    inherit IView
+
+type IImage =
+    inherit IView
+
+type IBoxView =
+    inherit IView
+
+type INavigationPage =
+    inherit IPage
+
+type IEntry =
+    inherit IView
+
+type ITapGestureRecognizer =
+    inherit IGestureRecognizer
+
+type ISearchBar =
+    inherit IView
+
+type IEditor =
+    inherit IView
+
+type IViewCell =
+    inherit ICell
+
+type IImageButton =
+    inherit IView
+
+type ITabbedPage =
+    inherit IPage
+
+type IDatePicker =
+    inherit IView
+
+type ITimePicker =
+    inherit IView
+
+type IStepper =
+    inherit IView
+
 module ViewKeys =
-    let Application = Widgets.register<Xamarin.Forms.Application>()
+    let Application =
+        Widgets.register<Xamarin.Forms.Application>()
+
     let ContentPage = Widgets.register<FabulousContentPage>()
-    let StackLayout = Widgets.register<Xamarin.Forms.StackLayout>()
+
+    let StackLayout =
+        Widgets.register<Xamarin.Forms.StackLayout>()
+
     let Grid = Widgets.register<Xamarin.Forms.Grid>()
     let Label = Widgets.register<Xamarin.Forms.Label>()
     let Button = Widgets.register<Xamarin.Forms.Button>()
     let Switch = Widgets.register<Xamarin.Forms.Switch>()
     let Slider = Widgets.register<Xamarin.Forms.Slider>()
-    let ActivityIndicator = Widgets.register<Xamarin.Forms.ActivityIndicator>()
-    let ContentView = Widgets.register<Xamarin.Forms.ContentView>()
-    let RefreshView = Widgets.register<Xamarin.Forms.RefreshView>()
-    let ScrollView = Widgets.register<Xamarin.Forms.ScrollView>()
+
+    let ActivityIndicator =
+        Widgets.register<Xamarin.Forms.ActivityIndicator>()
+
+    let ContentView =
+        Widgets.register<Xamarin.Forms.ContentView>()
+
+    let RefreshView =
+        Widgets.register<Xamarin.Forms.RefreshView>()
+
+    let ScrollView =
+        Widgets.register<Xamarin.Forms.ScrollView>()
+
     let Image = Widgets.register<Xamarin.Forms.Image>()
-    let BoxView = Widgets.register<Xamarin.Forms.BoxView>()
-    let NavigationPage = Widgets.register<Xamarin.Forms.NavigationPage>()
+
+    let BoxView =
+        Widgets.register<Xamarin.Forms.BoxView>()
+
+    let NavigationPage =
+        Widgets.register<Xamarin.Forms.NavigationPage>()
+
     let Entry = Widgets.register<Xamarin.Forms.Entry>()
-    let TapGestureRecognizer = Widgets.register<Xamarin.Forms.TapGestureRecognizer>()
-    let SearchBar = Widgets.register<Xamarin.Forms.SearchBar>()
-    let ToolbarItem = Widgets.register<Xamarin.Forms.ToolbarItem>()
+
+    let TapGestureRecognizer =
+        Widgets.register<Xamarin.Forms.TapGestureRecognizer>()
+
+    let SearchBar =
+        Widgets.register<Xamarin.Forms.SearchBar>()
+
+    let ToolbarItem =
+        Widgets.register<Xamarin.Forms.ToolbarItem>()
+
     let Editor = Widgets.register<Xamarin.Forms.Editor>()
-    let ViewCell = Widgets.register<Xamarin.Forms.ViewCell>()
-    let ImageButton = Widgets.register<Xamarin.Forms.ImageButton>()
-    let TabbedPage = Widgets.register<Xamarin.Forms.TabbedPage>()
-    let DatePicker = Widgets.register<Xamarin.Forms.DatePicker>()
+
+    let ViewCell =
+        Widgets.register<Xamarin.Forms.ViewCell>()
+
+    let ImageButton =
+        Widgets.register<Xamarin.Forms.ImageButton>()
+
+    let TabbedPage =
+        Widgets.register<Xamarin.Forms.TabbedPage>()
+
+    let DatePicker =
+        Widgets.register<Xamarin.Forms.DatePicker>()
+
     let TimePicker = Widgets.register<FabulousTimePicker>()
-    let Stepper = Widgets.register<Xamarin.Forms.Stepper>()
+
+    let Stepper =
+        Widgets.register<Xamarin.Forms.Stepper>()
 
 [<AbstractClass; Sealed>]
 type ViewBuilders private () =
     static member inline Application<'msg, 'marker when 'marker :> IPage>(mainPage: WidgetBuilder<'msg, 'marker>) =
-        ViewHelpers.buildWidgets<'msg, IApplication> ViewKeys.Application
-            [| Application.MainPage.WithValue(mainPage.Compile()) |]
-            
-    static member inline ContentPage<'msg, 'marker when 'marker :> IView>(title: string, content: WidgetBuilder<'msg, 'marker>) =
-        ViewHelpers.build<'msg, IContentPage> ViewKeys.ContentPage
-            [| Page.Title.WithValue(title) |]
-            [| ContentPage.Content.WithValue(content.Compile()) |]
-            [||]
-            
+        ViewHelpers.buildWidgets<'msg, IApplication>
+            ViewKeys.Application
+            [|
+                Application.MainPage.WithValue(mainPage.Compile())
+            |]
+
+    static member inline ContentPage<'msg, 'marker when 'marker :> IView>
+        (
+            title: string,
+            content: WidgetBuilder<'msg, 'marker>
+        ) =
+        WidgetBuilder<'msg, IContentPage>(
+            ViewKeys.ContentPage,
+            AttributesBundle(
+                StackArray3.one(Page.Title.WithValue(title)),
+                Some [| ContentPage.Content.WithValue(content.Compile()) |],
+                None
+            )
+        )
+
     static member inline StackLayout<'msg>(orientation: Xamarin.Forms.StackOrientation, ?spacing: float) =
-        ViewHelpers.buildCollection<'msg, IStackLayout, IView> ViewKeys.StackLayout LayoutOfView.Children
-            [| StackLayout.Orientation.WithValue(orientation)
-               match spacing with None -> () | Some v -> StackLayout.Spacing.WithValue(v) |]
-            
+        match spacing with
+        | None ->
+            CollectionBuilder<'msg, IStackLayout, IView>(
+                ViewKeys.StackLayout,
+                LayoutOfView.Children,
+                StackLayout.Orientation.WithValue(orientation)
+            )
+
+        | Some v ->
+            CollectionBuilder<'msg, IStackLayout, IView>(
+                ViewKeys.StackLayout,
+                LayoutOfView.Children,
+                StackLayout.Orientation.WithValue(orientation),
+                StackLayout.Spacing.WithValue(v)
+            )
+
+
     static member inline Grid<'msg>(coldefs: seq<Dimension>, rowdefs: seq<Dimension>) =
-        ViewHelpers.buildCollection<'msg, IGrid, IView> ViewKeys.Grid LayoutOfView.Children
-            [| Grid.ColumnDefinitions.WithValue(coldefs)
-               Grid.RowDefinitions.WithValue(rowdefs) |]
-            
+        CollectionBuilder<'msg, IGrid, IView>(
+            ViewKeys.Grid,
+            LayoutOfView.Children,
+            Grid.ColumnDefinitions.WithValue(coldefs),
+            Grid.RowDefinitions.WithValue(rowdefs)
+        )
+
     static member inline Label<'msg>(text: string) =
-        ViewHelpers.buildScalars<'msg, ILabel> ViewKeys.Label
-            [| Label.Text.WithValue(text) |]
-            
+        WidgetBuilder<'msg, ILabel>(ViewKeys.Label, Label.Text.WithValue(text))
+
+
     static member inline Button<'msg>(text: string, onClicked: 'msg) =
-        ViewHelpers.buildScalars<'msg, IButton> ViewKeys.Button
-            [| Button.Text.WithValue(text)
-               Button.Clicked.WithValue(onClicked) |]
-            
+        WidgetBuilder<'msg, IButton>(ViewKeys.Button, Button.Text.WithValue(text), Button.Clicked.WithValue(onClicked))
+
     static member inline Switch<'msg>(isToggled: bool, onToggled: bool -> 'msg) =
-        ViewHelpers.buildScalars<'msg, ISwitch> ViewKeys.Switch
-            [| Switch.IsToggled.WithValue(isToggled)
-               Switch.Toggled.WithValue(fun args -> onToggled args.Value |> box) |]
-            
+        WidgetBuilder<'msg, ISwitch>(
+            ViewKeys.Switch,
+            Switch.IsToggled.WithValue(isToggled),
+            Switch.Toggled.WithValue(fun args -> onToggled args.Value |> box)
+        )
+
     static member inline Slider<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
-        ViewHelpers.buildScalars<'msg, ISlider> ViewKeys.Slider
-            [| Slider.Value.WithValue(value)
-               Slider.ValueChanged.WithValue(fun args -> onValueChanged args.NewValue |> box)
-               Slider.MinimumMaximum.WithValue(min, max) |]
-            
+        WidgetBuilder<'msg, ISlider>(
+            ViewKeys.Slider,
+            Slider.Value.WithValue(value),
+            Slider.ValueChanged.WithValue(fun args -> onValueChanged args.NewValue |> box),
+            Slider.MinimumMaximum.WithValue(min, max)
+        )
+
     static member inline ActivityIndicator<'msg>(isRunning: bool) =
-        ViewHelpers.buildScalars<'msg, IActivityIndicator> ViewKeys.ActivityIndicator
-            [| ActivityIndicator.IsRunning.WithValue(isRunning) |]
-            
+        WidgetBuilder<'msg, IActivityIndicator>(
+            ViewKeys.ActivityIndicator,
+            ActivityIndicator.IsRunning.WithValue(isRunning)
+        )
+
     static member inline ContentView<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
-        ViewHelpers.buildWidgets<'msg, IContentView> ViewKeys.ContentView
-            [| ContentView.Content.WithValue(content.Compile()) |]
-    
-    static member inline RefreshView<'msg, 'marker when 'marker :> IView>(isRefreshing: bool, onRefreshing: 'msg, content: WidgetBuilder<'msg, 'marker>) =
-        ViewHelpers.build<'msg, IRefreshView> ViewKeys.RefreshView
-            [| RefreshView.IsRefreshing.WithValue(isRefreshing)
-               RefreshView.Refreshing.WithValue(onRefreshing) |]
-            [| ContentView.Content.WithValue(content.Compile()) |]
-            [||]
-            
+        ViewHelpers.buildWidgets<'msg, IContentView>
+            ViewKeys.ContentView
+            [|
+                ContentView.Content.WithValue(content.Compile())
+            |]
+
+    static member inline RefreshView<'msg, 'marker when 'marker :> IView>
+        (
+            isRefreshing: bool,
+            onRefreshing: 'msg,
+            content: WidgetBuilder<'msg, 'marker>
+        ) =
+        WidgetBuilder<'msg, IRefreshView>(
+            ViewKeys.RefreshView,
+
+            AttributesBundle(
+                StackArray3.two(
+                    RefreshView.IsRefreshing.WithValue(isRefreshing),
+                    RefreshView.Refreshing.WithValue(onRefreshing)
+                ),
+                Some [| ContentView.Content.WithValue(content.Compile()) |],
+                None
+            )
+        )
+
     static member inline ScrollView<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
-        ViewHelpers.buildWidgets<'msg, IScrollView> ViewKeys.ScrollView
-            [| ScrollView.Content.WithValue(content.Compile()) |]
-            
+        ViewHelpers.buildWidgets<'msg, IScrollView>
+            ViewKeys.ScrollView
+            [|
+                ScrollView.Content.WithValue(content.Compile())
+            |]
+
     static member inline SourceImage<'msg>(imageSource: Xamarin.Forms.ImageSource, aspect: Xamarin.Forms.Aspect) =
-        ViewHelpers.buildScalars<'msg, IImage> ViewKeys.Image
-            [| Image.Source.WithValue(imageSource)
-               Image.Aspect.WithValue(aspect) |]
-            
+        WidgetBuilder<'msg, IImage>(ViewKeys.Image, Image.Source.WithValue(imageSource), Image.Aspect.WithValue(aspect))
+
     static member inline FileImage<'msg>(path: string, aspect: Xamarin.Forms.Aspect) =
         ViewBuilders.SourceImage<'msg>(Xamarin.Forms.ImageSource.FromFile(path), aspect)
-        
+
     static member inline WebImage<'msg>(uri: Uri, aspect: Xamarin.Forms.Aspect) =
         ViewBuilders.SourceImage<'msg>(Xamarin.Forms.ImageSource.FromUri(uri), aspect)
-        
+
     static member inline StreamImage<'msg>(stream: Stream, aspect: Xamarin.Forms.Aspect) =
         ViewBuilders.SourceImage<'msg>(Xamarin.Forms.ImageSource.FromStream(fun () -> stream), aspect)
-        
+
     static member inline BoxView<'msg>(color: Xamarin.Forms.Color) =
-        ViewHelpers.buildScalars<'msg, IBoxView> ViewKeys.BoxView 
-            [| BoxView.Color.WithValue(color) |]
-              
+        WidgetBuilder<'msg, IBoxView>(ViewKeys.BoxView, BoxView.Color.WithValue(color))
+
     static member inline NavigationPage<'msg>() =
-        ViewHelpers.buildCollectionNoScalar<'msg, INavigationPage, IPage> ViewKeys.NavigationPage NavigationPage.Pages
-    
+        CollectionBuilder<'msg, INavigationPage, IPage>(ViewKeys.NavigationPage, NavigationPage.Pages)
+
     static member inline Entry<'msg>(text: string, onTextChanged: string -> 'msg) =
-        ViewHelpers.buildScalars<'msg, IEntry> ViewKeys.Entry
-            [| Entry.Text.WithValue(text)
-               Entry.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box) |]
-                                    
+        WidgetBuilder<'msg, IEntry>(
+            ViewKeys.Entry,
+            Entry.Text.WithValue(text),
+            Entry.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
+        )
+
     static member inline TapGestureRecognizer<'msg>(onTapped: 'msg) =
-        ViewHelpers.buildScalars<'msg, IGestureRecognizer> ViewKeys.TapGestureRecognizer
-            [| TapGestureRecognizer.Tapped.WithValue(onTapped) |]
-                      
+        WidgetBuilder<'msg, IGestureRecognizer>(
+            ViewKeys.TapGestureRecognizer,
+            TapGestureRecognizer.Tapped.WithValue(onTapped)
+        )
+
     static member inline SearchBar<'msg>(text: string, onTextChanged: string -> 'msg, onSearchButtonPressed: 'msg) =
-        ViewHelpers.buildScalars<'msg, ISearchBar> ViewKeys.SearchBar
-            [| SearchBar.Text.WithValue(text)
-               InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
-               SearchBar.SearchButtonPressed.WithValue(onSearchButtonPressed) |]
-                                    
+        WidgetBuilder<'msg, ISearchBar>(
+            ViewKeys.SearchBar,
+            SearchBar.Text.WithValue(text),
+            InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box),
+            SearchBar.SearchButtonPressed.WithValue(onSearchButtonPressed)
+        )
+
     static member inline ToolbarItem<'msg>(text: string, onClicked: 'msg) =
-        ViewHelpers.buildScalars<'msg, IToolbarItem> ViewKeys.ToolbarItem
-            [| MenuItem.Text.WithValue(text)
-               MenuItem.Clicked.WithValue(onClicked) |]
-                                    
+        WidgetBuilder<'msg, IToolbarItem>(
+            ViewKeys.ToolbarItem,
+            MenuItem.Text.WithValue(text),
+            MenuItem.Clicked.WithValue(onClicked)
+        )
+
     static member inline Editor<'msg>(text: string, onTextChanged: string -> 'msg) =
-        ViewHelpers.buildScalars<'msg, IEditor> ViewKeys.Editor
-            [| Editor.Text.WithValue(text)
-               InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box) |]
-                                                  
+        WidgetBuilder<'msg, IEditor>(
+            ViewKeys.Editor,
+            Editor.Text.WithValue(text),
+            InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
+        )
+
     static member inline ViewCell<'msg, 'marker when 'marker :> IView>(view: WidgetBuilder<'msg, 'marker>) =
-        ViewHelpers.buildWidgets<'msg, IViewCell> ViewKeys.ViewCell
-            [| ViewCell.View.WithValue(view.Compile()) |]
-                                                  
-    static member inline SourceImageButton<'msg>(source: Xamarin.Forms.ImageSource, onClicked: 'msg, aspect: Xamarin.Forms.Aspect) =
-        ViewHelpers.buildScalars<'msg, IImageButton> ViewKeys.ImageButton
-            [| ImageButton.Source.WithValue(source)
-               ImageButton.Clicked.WithValue(onClicked)
-               ImageButton.Aspect.WithValue(aspect) |]
+        ViewHelpers.buildWidgets<'msg, IViewCell>
+            ViewKeys.ViewCell
+            [|
+                ViewCell.View.WithValue(view.Compile())
+            |]
+
+    static member inline SourceImageButton<'msg>
+        (
+            source: Xamarin.Forms.ImageSource,
+            onClicked: 'msg,
+            aspect: Xamarin.Forms.Aspect
+        ) =
+        WidgetBuilder<'msg, IImageButton>(
+            ViewKeys.ImageButton,
+            ImageButton.Source.WithValue(source),
+            ImageButton.Clicked.WithValue(onClicked),
+            ImageButton.Aspect.WithValue(aspect)
+        )
 
     static member inline FileImageButton<'msg>(path: string, onClicked, aspect) =
         ViewBuilders.SourceImageButton<'msg>(Xamarin.Forms.ImageSource.FromFile(path), onClicked, aspect)
-        
+
     static member inline WebImageButton<'msg>(uri: Uri, onClicked, aspect) =
         ViewBuilders.SourceImageButton<'msg>(Xamarin.Forms.ImageSource.FromUri(uri), onClicked, aspect)
-        
+
     static member inline StreamImageButton<'msg>(stream: Stream, onClicked, aspect) =
         ViewBuilders.SourceImageButton<'msg>(Xamarin.Forms.ImageSource.FromStream(fun () -> stream), onClicked, aspect)
-                                                  
+
     static member inline TabbedPage<'msg>(title: string) =
-        ViewHelpers.buildCollection<'msg, ITabbedPage, IPage> ViewKeys.TabbedPage MultiPageOfPage.Children
-            [| Page.Title.WithValue(title) |]
-            
+        CollectionBuilder<'msg, ITabbedPage, IPage>(
+            ViewKeys.TabbedPage,
+            MultiPageOfPage.Children,
+            Page.Title.WithValue(title)
+        )
+
     static member inline DatePicker<'msg>(date: DateTime, onDateSelected: DateTime -> 'msg) =
-        ViewHelpers.buildScalars<'msg, IDatePicker> ViewKeys.DatePicker
-            [| DatePicker.Date.WithValue(date)
-               DatePicker.DateSelected.WithValue(fun args -> onDateSelected args.NewDate |> box) |]
-            
+        WidgetBuilder<'msg, IDatePicker>(
+            ViewKeys.DatePicker,
+            DatePicker.Date.WithValue(date),
+            DatePicker.DateSelected.WithValue(fun args -> onDateSelected args.NewDate |> box)
+        )
+
     static member inline TimePicker<'msg>(time: TimeSpan, onTimeSelected: TimeSpan -> 'msg) =
-        ViewHelpers.build<'msg, ITimePicker> ViewKeys.TimePicker
-            [| TimePicker.Time.WithValue(time)
-               TimePicker.TimeSelected.WithValue(fun args -> onTimeSelected args.NewTime |> box) |]
-            
+        WidgetBuilder<'msg, ITimePicker>(
+            ViewKeys.TimePicker,
+            TimePicker.Time.WithValue(time),
+            TimePicker.TimeSelected.WithValue(fun args -> onTimeSelected args.NewTime |> box)
+        )
+
     static member inline Stepper<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
-        ViewHelpers.build<'msg, IStepper> ViewKeys.Stepper
-            [| Stepper.Value.WithValue(value)
-               Stepper.ValueChanged.WithValue(fun args -> onValueChanged args.NewValue |> box)
-               Stepper.MinimumMaximum.WithValue((min, max)) |]
-    
+        WidgetBuilder<'msg, IStepper>(
+            ViewKeys.Stepper,
+            Stepper.Value.WithValue(value),
+            Stepper.ValueChanged.WithValue(fun args -> onValueChanged args.NewValue |> box),
+            Stepper.MinimumMaximum.WithValue((min, max))
+        )
+
 [<AbstractClass; Sealed>]
-type View private () =    
-    static member inline Application<'msg, 'marker when 'marker :> IPage>(mainPage) = ViewBuilders.Application<'msg, 'marker>(mainPage)
-    static member inline ContentPage<'msg, 'marker when 'marker :> IView>(title, content) = ViewBuilders.ContentPage<'msg, 'marker>(title, content)
-    static member inline HorizontalStackLayout<'msg>(?spacing) = ViewBuilders.StackLayout<'msg>(Xamarin.Forms.StackOrientation.Horizontal, ?spacing = spacing)
-    static member inline VerticalStackLayout<'msg>(?spacing) = ViewBuilders.StackLayout<'msg>(Xamarin.Forms.StackOrientation.Vertical, ?spacing = spacing)
-    static member inline Grid<'msg>() = ViewBuilders.Grid<'msg>([Star], [Star])
-    static member inline Grid<'msg>(coldefs, rowdefs) = ViewBuilders.Grid<'msg>(coldefs, rowdefs)
+type View private () =
+    static member inline Application<'msg, 'marker when 'marker :> IPage>(mainPage) =
+        ViewBuilders.Application<'msg, 'marker>(mainPage)
+
+    static member inline ContentPage<'msg, 'marker when 'marker :> IView>(title, content) =
+        ViewBuilders.ContentPage<'msg, 'marker>(title, content)
+
+    static member inline HorizontalStackLayout<'msg>(?spacing) =
+        ViewBuilders.StackLayout<'msg>(Xamarin.Forms.StackOrientation.Horizontal, ?spacing = spacing)
+
+    static member inline VerticalStackLayout<'msg>(?spacing) =
+        ViewBuilders.StackLayout<'msg>(Xamarin.Forms.StackOrientation.Vertical, ?spacing = spacing)
+
+    static member inline Grid<'msg>() =
+        ViewBuilders.Grid<'msg>([ Star ], [ Star ])
+
+    static member inline Grid<'msg>(coldefs, rowdefs) =
+        ViewBuilders.Grid<'msg>(coldefs, rowdefs)
+
     static member inline Label<'msg>(text) = ViewBuilders.Label<'msg>(text)
-    static member inline Button<'msg>(text, onClicked) = ViewBuilders.Button<'msg>(text, onClicked)
-    static member inline Switch<'msg>(isToggled, onToggled) = ViewBuilders.Switch<'msg>(isToggled, onToggled)
-    static member inline Slider<'msg>(min, max, value, onValueChanged) = ViewBuilders.Slider<'msg>(min, max, value, onValueChanged)
-    static member inline ActivityIndicator<'msg>(isRunning) = ViewBuilders.ActivityIndicator<'msg>(isRunning)
-    static member inline ContentView<'msg, 'marker when 'marker :> IView>(content) = ViewBuilders.ContentView<'msg, 'marker>(content)
-    static member inline RefreshView<'msg, 'marker when 'marker :> IView>(isRefreshing, onRefreshing, content) = ViewBuilders.RefreshView<'msg, 'marker>(isRefreshing, onRefreshing, content)
-    static member inline ScrollView<'msg, 'marker when 'marker :> IView>(content) = ViewBuilders.ScrollView<'msg, 'marker>(content)
-    static member inline Image<'msg>(imageSource, aspect) = ViewBuilders.SourceImage<'msg>(imageSource, aspect)
-    static member inline Image<'msg>(path, aspect) = ViewBuilders.FileImage<'msg>(path, aspect)
-    static member inline Image<'msg>(uri, aspect) = ViewBuilders.WebImage<'msg>(uri, aspect)
-    static member inline Image<'msg>(stream, aspect) = ViewBuilders.StreamImage<'msg>(stream, aspect)
+
+    static member inline Button<'msg>(text, onClicked) =
+        ViewBuilders.Button<'msg>(text, onClicked)
+
+    static member inline Switch<'msg>(isToggled, onToggled) =
+        ViewBuilders.Switch<'msg>(isToggled, onToggled)
+
+    static member inline Slider<'msg>(min, max, value, onValueChanged) =
+        ViewBuilders.Slider<'msg>(min, max, value, onValueChanged)
+
+    static member inline ActivityIndicator<'msg>(isRunning) =
+        ViewBuilders.ActivityIndicator<'msg>(isRunning)
+
+    static member inline ContentView<'msg, 'marker when 'marker :> IView>(content) =
+        ViewBuilders.ContentView<'msg, 'marker>(content)
+
+    static member inline RefreshView<'msg, 'marker when 'marker :> IView>(isRefreshing, onRefreshing, content) =
+        ViewBuilders.RefreshView<'msg, 'marker>(isRefreshing, onRefreshing, content)
+
+    static member inline ScrollView<'msg, 'marker when 'marker :> IView>(content) =
+        ViewBuilders.ScrollView<'msg, 'marker>(content)
+
+    static member inline Image<'msg>(imageSource, aspect) =
+        ViewBuilders.SourceImage<'msg>(imageSource, aspect)
+
+    static member inline Image<'msg>(path, aspect) =
+        ViewBuilders.FileImage<'msg>(path, aspect)
+
+    static member inline Image<'msg>(uri, aspect) =
+        ViewBuilders.WebImage<'msg>(uri, aspect)
+
+    static member inline Image<'msg>(stream, aspect) =
+        ViewBuilders.StreamImage<'msg>(stream, aspect)
+
     static member inline BoxView<'msg>(color) = ViewBuilders.BoxView<'msg>(color)
     static member inline NavigationPage<'msg>() = ViewBuilders.NavigationPage<'msg>()
-    static member inline Entry<'msg>(text, onTextChanged) = ViewBuilders.Entry<'msg>(text, onTextChanged)
-    static member inline TapGestureRecognizer<'msg>(onTapped) = ViewBuilders.TapGestureRecognizer<'msg>(onTapped)
-    static member inline SearchBar<'msg>(text, onTextChanged, onSearchButtonPressed) = ViewBuilders.SearchBar<'msg>(text, onTextChanged, onSearchButtonPressed)
-    static member inline ToolbarItem<'msg>(text, onClicked) = ViewBuilders.ToolbarItem<'msg>(text, onClicked)
-    static member inline Editor<'msg>(text, onTextChanged) = ViewBuilders.Editor<'msg>(text, onTextChanged)
-    static member inline ViewCell<'msg, 'marker when 'marker :> IView>(content) = ViewBuilders.ViewCell<'msg, 'marker>(content)
-    static member inline ImageButton<'msg>(imageSource, onClicked, aspect) = ViewBuilders.SourceImageButton<'msg>(imageSource, onClicked, aspect)
-    static member inline ImageButton<'msg>(path, onClicked, aspect) = ViewBuilders.FileImageButton<'msg>(path, onClicked, aspect)
-    static member inline ImageButton<'msg>(uri, onClicked, aspect) = ViewBuilders.WebImageButton<'msg>(uri, onClicked, aspect)
-    static member inline ImageButton<'msg>(stream, onClicked, aspect) = ViewBuilders.StreamImageButton<'msg>(stream, onClicked, aspect)
+
+    static member inline Entry<'msg>(text, onTextChanged) =
+        ViewBuilders.Entry<'msg>(text, onTextChanged)
+
+    static member inline TapGestureRecognizer<'msg>(onTapped) =
+        ViewBuilders.TapGestureRecognizer<'msg>(onTapped)
+
+    static member inline SearchBar<'msg>(text, onTextChanged, onSearchButtonPressed) =
+        ViewBuilders.SearchBar<'msg>(text, onTextChanged, onSearchButtonPressed)
+
+    static member inline ToolbarItem<'msg>(text, onClicked) =
+        ViewBuilders.ToolbarItem<'msg>(text, onClicked)
+
+    static member inline Editor<'msg>(text, onTextChanged) =
+        ViewBuilders.Editor<'msg>(text, onTextChanged)
+
+    static member inline ViewCell<'msg, 'marker when 'marker :> IView>(content) =
+        ViewBuilders.ViewCell<'msg, 'marker>(content)
+
+    static member inline ImageButton<'msg>(imageSource, onClicked, aspect) =
+        ViewBuilders.SourceImageButton<'msg>(imageSource, onClicked, aspect)
+
+    static member inline ImageButton<'msg>(path, onClicked, aspect) =
+        ViewBuilders.FileImageButton<'msg>(path, onClicked, aspect)
+
+    static member inline ImageButton<'msg>(uri, onClicked, aspect) =
+        ViewBuilders.WebImageButton<'msg>(uri, onClicked, aspect)
+
+    static member inline ImageButton<'msg>(stream, onClicked, aspect) =
+        ViewBuilders.StreamImageButton<'msg>(stream, onClicked, aspect)
+
     static member inline TabbedPage<'msg>(title) = ViewBuilders.TabbedPage<'msg>(title)
-    static member inline DatePicker<'msg>(date, onDateSelected) = ViewBuilders.DatePicker<'msg>(date, onDateSelected)
-    static member inline TimePicker<'msg>(time, onTimeSelected) = ViewBuilders.TimePicker<'msg>(time, onTimeSelected)
-    static member inline Stepper<'msg>(min, max, value, onValueChanged) = ViewBuilders.Stepper<'msg>(min, max, value, onValueChanged)        
+
+    static member inline DatePicker<'msg>(date, onDateSelected) =
+        ViewBuilders.DatePicker<'msg>(date, onDateSelected)
+
+    static member inline TimePicker<'msg>(time, onTimeSelected) =
+        ViewBuilders.TimePicker<'msg>(time, onTimeSelected)
+
+    static member inline Stepper<'msg>(min, max, value, onValueChanged) =
+        ViewBuilders.Stepper<'msg>(min, max, value, onValueChanged)
 
 [<Extension; AbstractClass; Sealed>]
 type ViewExtensions private () =
     [<Extension>]
     static member inline userAppTheme(this: WidgetBuilder<'msg, #IApplication>, value: Xamarin.Forms.OSAppTheme) =
         this.AddScalar(Application.UserAppTheme.WithValue(value))
+
     [<Extension>]
     static member inline resources(this: WidgetBuilder<'msg, #IApplication>, value: Xamarin.Forms.ResourceDictionary) =
         this.AddScalar(Application.Resources.WithValue(value))
+
     [<Extension>]
-    static member inline onRequestedThemeChanged(this: WidgetBuilder<'msg, #IApplication>, fn: Xamarin.Forms.AppThemeChangedEventArgs -> 'msg) =
+    static member inline onRequestedThemeChanged
+        (
+            this: WidgetBuilder<'msg, #IApplication>,
+            fn: Xamarin.Forms.AppThemeChangedEventArgs -> 'msg
+        ) =
         this.AddScalar(Application.RequestedThemeChanged.WithValue(fn >> box))
+
     [<Extension>]
-    static member inline onModalPopped(this: WidgetBuilder<'msg, #IApplication>, fn: Xamarin.Forms.ModalPoppedEventArgs -> 'msg) =
+    static member inline onModalPopped
+        (
+            this: WidgetBuilder<'msg, #IApplication>,
+            fn: Xamarin.Forms.ModalPoppedEventArgs -> 'msg
+        ) =
         this.AddScalar(Application.ModalPopped.WithValue(fn >> box))
+
     [<Extension>]
-    static member inline onModalPopping(this: WidgetBuilder<'msg, #IApplication>, fn: Xamarin.Forms.ModalPoppingEventArgs -> 'msg) =
+    static member inline onModalPopping
+        (
+            this: WidgetBuilder<'msg, #IApplication>,
+            fn: Xamarin.Forms.ModalPoppingEventArgs -> 'msg
+        ) =
         this.AddScalar(Application.ModalPopping.WithValue(fn >> box))
+
     [<Extension>]
-    static member inline onModalPushed(this: WidgetBuilder<'msg, #IApplication>, fn: Xamarin.Forms.ModalPushedEventArgs -> 'msg) =
+    static member inline onModalPushed
+        (
+            this: WidgetBuilder<'msg, #IApplication>,
+            fn: Xamarin.Forms.ModalPushedEventArgs -> 'msg
+        ) =
         this.AddScalar(Application.ModalPushed.WithValue(fn >> box))
+
     [<Extension>]
-    static member inline onModalPushing(this: WidgetBuilder<'msg, #IApplication>, fn: Xamarin.Forms.ModalPushingEventArgs -> 'msg) =
+    static member inline onModalPushing
+        (
+            this: WidgetBuilder<'msg, #IApplication>,
+            fn: Xamarin.Forms.ModalPushingEventArgs -> 'msg
+        ) =
         this.AddScalar(Application.ModalPushing.WithValue(fn >> box))
+
     [<Extension>]
     static member inline automationId(this: WidgetBuilder<'msg, #IView>, value: string) =
         this.AddScalar(Element.AutomationId.WithValue(value))
+
     [<Extension>]
     static member inline isEnabled(this: WidgetBuilder<'msg, #IView>, value: bool) =
         this.AddScalar(VisualElement.IsEnabled.WithValue(value))
+
     [<Extension>]
     static member inline opacity(this: WidgetBuilder<'msg, #IView>, value: float) =
         this.AddScalar(VisualElement.Opacity.WithValue(value))
+
     [<Extension>]
     static member inline backgroundColor(this: WidgetBuilder<'msg, #IView>, value: Xamarin.Forms.Color) =
         this.AddScalar(VisualElement.BackgroundColor.WithValue(value))
+
     [<Extension>]
     static member inline isVisible(this: WidgetBuilder<'msg, #IView>, value: bool) =
         this.AddScalar(VisualElement.IsVisible.WithValue(value))
+
     [<Extension>]
     static member inline horizontalOptions(this: WidgetBuilder<'msg, #IView>, value: Xamarin.Forms.LayoutOptions) =
         this.AddScalar(View.HorizontalOptions.WithValue(value))
+
     [<Extension>]
     static member inline verticalOptions(this: WidgetBuilder<'msg, #IView>, value: Xamarin.Forms.LayoutOptions) =
         this.AddScalar(View.VerticalOptions.WithValue(value))
+
     [<Extension>]
     static member inline margin(this: WidgetBuilder<'msg, #IView>, value: Xamarin.Forms.Thickness) =
         this.AddScalar(View.Margin.WithValue(value))
+
     [<Extension>]
     static member inline gestureRecognizers<'msg, 'marker when 'marker :> IView>(this: WidgetBuilder<'msg, 'marker>) =
         ViewHelpers.buildAttributeCollection<'msg, 'marker, IGestureRecognizer> View.GestureRecognizers this
+
     [<Extension>]
-    static member inline horizontalTextAlignment(this: WidgetBuilder<'msg, #ILabel>, value: Xamarin.Forms.TextAlignment) =
+    static member inline horizontalTextAlignment
+        (
+            this: WidgetBuilder<'msg, #ILabel>,
+            value: Xamarin.Forms.TextAlignment
+        ) =
         this.AddScalar(Label.HorizontalTextAlignment.WithValue(value))
+
     [<Extension>]
     static member inline verticalTextAlignment(this: WidgetBuilder<'msg, #ILabel>, value: Xamarin.Forms.TextAlignment) =
         this.AddScalar(Label.VerticalTextAlignment.WithValue(value))
+
     [<Extension>]
     static member inline font(this: WidgetBuilder<'msg, #ILabel>, value: double) =
         this.AddScalar(Label.FontSize.WithValue(value))
+
     [<Extension>]
     static member inline textColor(this: WidgetBuilder<'msg, #ILabel>, value: Xamarin.Forms.Color) =
         this.AddScalar(Label.TextColor.WithValue(value))
+
     [<Extension>]
     static member inline padding(this: WidgetBuilder<'msg, #IView>, value: Xamarin.Forms.Thickness) =
         this.AddScalar(Label.Padding.WithValue(value))
+
     [<Extension>]
-    static member inline textColor(this: WidgetBuilder<'msg, IButton>, light: Xamarin.Forms.Color, ?dark: Xamarin.Forms.Color) =
-        this.AddScalar(Button.TextColor.WithValue({ Light = light; Dark = match dark with None -> ValueNone | Some v -> ValueSome v }))
+    static member inline textColor
+        (
+            this: WidgetBuilder<'msg, IButton>,
+            light: Xamarin.Forms.Color,
+            ?dark: Xamarin.Forms.Color
+        ) =
+        this.AddScalar(
+            Button.TextColor.WithValue(
+                {
+                    Light = light
+                    Dark =
+                        match dark with
+                        | None -> ValueNone
+                        | Some v -> ValueSome v
+                }
+            )
+        )
+
     [<Extension>]
     static member inline font(this: WidgetBuilder<'msg, IButton>, value: double) =
         this.AddScalar(Button.FontSize.WithValue(value))
+
     [<Extension>]
     static member inline paddingLayout(this: WidgetBuilder<'msg, #ILayout>, value: Xamarin.Forms.Thickness) =
         this.AddScalar(Layout.Padding.WithValue(value))
+
     [<Extension>]
     static member inline gridColumn(this: WidgetBuilder<'msg, #IView>, value: int) =
         this.AddScalar(Grid.Column.WithValue(value))
+
     [<Extension>]
     static member inline gridRow(this: WidgetBuilder<'msg, #IView>, value: int) =
         this.AddScalar(Grid.Row.WithValue(value))
+
     [<Extension>]
     static member inline columnSpacing(this: WidgetBuilder<'msg, #IGrid>, value: float) =
         this.AddScalar(Grid.ColumnSpacing.WithValue(value))
+
     [<Extension>]
     static member inline rowSpacing(this: WidgetBuilder<'msg, #IGrid>, value: float) =
         this.AddScalar(Grid.RowSpacing.WithValue(value))
+
     [<Extension>]
     static member inline gridColumnSpan(this: WidgetBuilder<'msg, #IView>, value: int) =
         this.AddScalar(Grid.ColumnSpan.WithValue(value))
+
     [<Extension>]
     static member inline gridRowSpan(this: WidgetBuilder<'msg, #IView>, value: int) =
         this.AddScalar(Grid.RowSpan.WithValue(value))
+
     [<Extension>]
     static member inline onSizeAllocated(this: WidgetBuilder<'msg, #IContentPage>, fn: SizeAllocatedEventArgs -> 'msg) =
         this.AddScalar(ContentPage.SizeAllocated.WithValue(fn >> box))
+
     [<Extension>]
     static member inline barBackgroundColor(this: WidgetBuilder<'msg, #INavigationPage>, value: Xamarin.Forms.Color) =
         this.AddScalar(NavigationPage.BarBackgroundColor.WithValue(value))
+
     [<Extension>]
     static member inline popped(this: WidgetBuilder<'msg, #INavigationPage>, value: 'msg) =
         this.AddScalar(NavigationPage.Popped.WithValue(fun _ -> box value))
+
     [<Extension>]
     static member inline barTextColor(this: WidgetBuilder<'msg, #INavigationPage>, value: Xamarin.Forms.Color) =
         this.AddScalar(NavigationPage.BarTextColor.WithValue(value))
+
     [<Extension>]
     static member inline height(this: WidgetBuilder<'msg, #IView>, value: float) =
         this.AddScalar(VisualElement.Height.WithValue(value))
+
     [<Extension>]
     static member inline width(this: WidgetBuilder<'msg, #IView>, value: float) =
         this.AddScalar(VisualElement.Width.WithValue(value))
+
     [<Extension>]
     static member inline placeholder(this: WidgetBuilder<'msg, #IEntry>, value: string) =
         this.AddScalar(Entry.Placeholder.WithValue(value))
+
     [<Extension>]
     static member inline keyboard(this: WidgetBuilder<'msg, #IEntry>, value: Xamarin.Forms.Keyboard) =
         this.AddScalar(Entry.Keyboard.WithValue(value))
+
     [<Extension>]
     static member inline title(this: WidgetBuilder<'msg, #IPage>, value: string) =
         this.AddScalar(Page.Title.WithValue(value))
+
     [<Extension>]
     static member inline fileIcon(this: WidgetBuilder<'msg, #IPage>, value: string) =
         this.AddScalar(Page.IconImageSource.WithValue(Xamarin.Forms.ImageSource.FromFile(value)))
+
     [<Extension>]
     static member inline onAppearing(this: WidgetBuilder<'msg, #IPage>, value: 'msg) =
         this.AddScalar(Page.Appearing.WithValue(value))
+
     [<Extension>]
     static member inline onDisappearing(this: WidgetBuilder<'msg, #IPage>, value: 'msg) =
         this.AddScalar(Page.Disappearing.WithValue(value))
+
     [<Extension>]
     static member inline onLayoutChanged(this: WidgetBuilder<'msg, #IPage>, value: 'msg) =
         this.AddScalar(Page.LayoutChanged.WithValue(value))
+
     [<Extension>]
     static member inline cancelButtonColor(this: WidgetBuilder<'msg, #ISearchBar>, value: Xamarin.Forms.Color) =
         this.AddScalar(SearchBar.CancelButtonColor.WithValue(value))
+
     [<Extension>]
     static member inline toolbarItems<'msg, 'marker when 'marker :> IPage>(this: WidgetBuilder<'msg, 'marker>) =
         ViewHelpers.buildAttributeCollection<'msg, 'marker, IToolbarItem> Page.ToolbarItems this
+
     [<Extension>]
     static member inline order(this: WidgetBuilder<'msg, #IToolbarItem>, value: Xamarin.Forms.ToolbarItemOrder) =
         this.AddScalar(ToolbarItem.Order.WithValue(value))
+
     [<Extension>]
     static member inline lineBreakMode(this: WidgetBuilder<'msg, #ILabel>, value: Xamarin.Forms.LineBreakMode) =
         this.AddScalar(Label.LineBreakMode.WithValue(value))
+
     [<Extension>]
     static member inline hasNavigationBar(this: WidgetBuilder<'msg, #IPage>, value: bool) =
         this.AddScalar(NavigationPage.HasNavigationBar.WithValue(value))
+
     [<Extension>]
     static member inline hasBackButton(this: WidgetBuilder<'msg, #IPage>, value: bool) =
         this.AddScalar(NavigationPage.HasBackButton.WithValue(value))
+
     [<Extension>]
     static member inline characterSpacing(this: WidgetBuilder<'msg, IDatePicker>, value: float) =
         this.AddScalar(DatePicker.CharacterSpacing.WithValue(value))
+
     [<Extension>]
     static member inline fontAttributes(this: WidgetBuilder<'msg, IDatePicker>, value: Xamarin.Forms.FontAttributes) =
         this.AddScalar(DatePicker.FontAttributes.WithValue(value))
+
     [<Extension>]
     static member inline fontFamily(this: WidgetBuilder<'msg, IDatePicker>, value: string) =
         this.AddScalar(DatePicker.FontFamily.WithValue(value))
+
     [<Extension>]
     static member inline fontSize(this: WidgetBuilder<'msg, IDatePicker>, value: float) =
         this.AddScalar(DatePicker.FontSize.WithValue(value))
+
     [<Extension>]
-    static member inline format(this: WidgetBuilder<'msg, IDatePicker>, value: string)=
+    static member inline format(this: WidgetBuilder<'msg, IDatePicker>, value: string) =
         this.AddScalar(DatePicker.Format.WithValue(value))
+
     [<Extension>]
     static member inline minimumDate(this: WidgetBuilder<'msg, IDatePicker>, value: DateTime) =
         this.AddScalar(DatePicker.MinimumDate.WithValue(value))
+
     [<Extension>]
     static member inline maximumDate(this: WidgetBuilder<'msg, IDatePicker>, value: DateTime) =
         this.AddScalar(DatePicker.MaximumDate.WithValue(value))
+
     [<Extension>]
-    static member inline textColor(this: WidgetBuilder<'msg, IDatePicker>, light: Xamarin.Forms.Color, ?dark: Xamarin.Forms.Color) =
-        this.AddScalar(DatePicker.TextColor.WithValue({ Light = light; Dark = match dark with None -> ValueNone | Some v -> ValueSome v }))
+    static member inline textColor
+        (
+            this: WidgetBuilder<'msg, IDatePicker>,
+            light: Xamarin.Forms.Color,
+            ?dark: Xamarin.Forms.Color
+        ) =
+        this.AddScalar(
+            DatePicker.TextColor.WithValue(
+                {
+                    Light = light
+                    Dark =
+                        match dark with
+                        | None -> ValueNone
+                        | Some v -> ValueSome v
+                }
+            )
+        )
+
     [<Extension>]
     static member inline textTransform(this: WidgetBuilder<'msg, IDatePicker>, value: Xamarin.Forms.TextTransform) =
         this.AddScalar(DatePicker.TextTransform.WithValue(value))
+
     [<Extension>]
     static member inline characterSpacing(this: WidgetBuilder<'msg, #ITimePicker>, value: float) =
         this.AddScalar(TimePicker.CharacterSpacing.WithValue(value))
+
     [<Extension>]
     static member inline fontAttributes(this: WidgetBuilder<'msg, #ITimePicker>, value: Xamarin.Forms.FontAttributes) =
         this.AddScalar(TimePicker.FontAttributes.WithValue(value))
+
     [<Extension>]
     static member inline fontFamily(this: WidgetBuilder<'msg, #ITimePicker>, value: string) =
         this.AddScalar(TimePicker.FontFamily.WithValue(value))
+
     [<Extension>]
     static member inline fontSize(this: WidgetBuilder<'msg, #ITimePicker>, value: float) =
         this.AddScalar(TimePicker.FontSize.WithValue(value))
+
     [<Extension>]
-    static member inline format(this: WidgetBuilder<'msg, #ITimePicker>, value: string)=
+    static member inline format(this: WidgetBuilder<'msg, #ITimePicker>, value: string) =
         this.AddScalar(TimePicker.Format.WithValue(value))
+
     [<Extension>]
-    static member inline textColor(this: WidgetBuilder<'msg, #ITimePicker>, light: Xamarin.Forms.Color, ?dark: Xamarin.Forms.Color) =
-        this.AddScalar(TimePicker.TextColor.WithValue({ Light = light; Dark = match dark with None -> ValueNone | Some v -> ValueSome v }))
+    static member inline textColor
+        (
+            this: WidgetBuilder<'msg, #ITimePicker>,
+            light: Xamarin.Forms.Color,
+            ?dark: Xamarin.Forms.Color
+        ) =
+        this.AddScalar(
+            TimePicker.TextColor.WithValue(
+                {
+                    Light = light
+                    Dark =
+                        match dark with
+                        | None -> ValueNone
+                        | Some v -> ValueSome v
+                }
+            )
+        )
+
     [<Extension>]
     static member inline textTransform(this: WidgetBuilder<'msg, #ITimePicker>, value: Xamarin.Forms.TextTransform) =
         this.AddScalar(TimePicker.TextTransform.WithValue(value))
+
     [<Extension>]
     static member inline increment(this: WidgetBuilder<'msg, #IStepper>, value: float) =
         this.AddScalar(Stepper.Increment.WithValue(value))

--- a/src/Fabulous.XamarinForms/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.XamarinForms/Xamarin.Forms.Core.fs
@@ -2,6 +2,7 @@ namespace Fabulous.XamarinForms
 
 open Fabulous
 open Fabulous.StackAllocatedCollections
+open Fabulous.StackAllocatedCollections.StackList
 open Fabulous.XamarinForms
 open Fabulous.XamarinForms.XFAttributes
 open System.Runtime.CompilerServices
@@ -163,7 +164,7 @@ type ViewBuilders private () =
         WidgetBuilder<'msg, IContentPage>(
             ViewKeys.ContentPage,
             AttributesBundle(
-                StackArray3.one(Page.Title.WithValue(title)),
+                StackList.one(Page.Title.WithValue(title)),
                 Some [| ContentPage.Content.WithValue(content.Compile()) |],
                 None
             )
@@ -240,7 +241,7 @@ type ViewBuilders private () =
             ViewKeys.RefreshView,
 
             AttributesBundle(
-                StackArray3.two(
+                StackList.two(
                     RefreshView.IsRefreshing.WithValue(isRefreshing),
                     RefreshView.Refreshing.WithValue(onRefreshing)
                 ),

--- a/src/Fabulous.XamarinForms/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.XamarinForms/Xamarin.Forms.Core.fs
@@ -165,8 +165,8 @@ type ViewBuilders private () =
             ViewKeys.ContentPage,
             AttributesBundle(
                 StackList.one(Page.Title.WithValue(title)),
-                Some [| ContentPage.Content.WithValue(content.Compile()) |],
-                None
+                ValueSome [| ContentPage.Content.WithValue(content.Compile()) |],
+                ValueNone
             )
         )
 
@@ -245,8 +245,8 @@ type ViewBuilders private () =
                     RefreshView.IsRefreshing.WithValue(isRefreshing),
                     RefreshView.Refreshing.WithValue(onRefreshing)
                 ),
-                Some [| ContentView.Content.WithValue(content.Compile()) |],
-                None
+                ValueSome [| ContentView.Content.WithValue(content.Compile()) |],
+                ValueNone
             )
         )
 

--- a/src/Fabulous/ArrayExtra.fs
+++ b/src/Fabulous/ArrayExtra.fs
@@ -1,8 +1,30 @@
 namespace Fabulous
 
+open Microsoft.FSharp.Core
+
+// TODO try to use it to optimize ArraySlice<'t> voption type
+// that is, potentially save on padding + optimize readability
+//
+//[<Struct; RequireQualifiedAccess; NoComparison>]
+//type PartialArray<'v> =
+//    | Empty
+//    | Filled of ArraySlice<'v>
+//
+//module PartialArray =
+//    let inline isEmpty (arr: PartialArray<'v>) : bool =
+//        match arr with
+//        | PartialArray.Empty -> true
+//        | PartialArray.Filled (used, _) -> used > 0us
+//
+//    let inline fromArray (arr: 'v []) : PartialArray<'v> =
+//        match arr.Length with
+//        | 0 -> PartialArray.Empty
+//        | len -> PartialArray.Filled(uint16 len, arr)
+
+
 module Array =
     let inline appendOne (v: 'v) (arr: 'v array) =
-        let res = Array.zeroCreate (arr.Length + 1)
+        let res = Array.zeroCreate(arr.Length + 1)
         Array.blit arr 0 res 0 arr.Length
         res.[arr.Length] <- v
         res
@@ -18,7 +40,7 @@ module Array =
         for i in [ 1 .. N - 1 ] do
             for j = i downto 1 do
                 let key = getKey attrs.[j]
-                let prevKey = getKey (attrs.[j - 1])
+                let prevKey = getKey(attrs.[j - 1])
 
                 if key < prevKey then
                     let temp = attrs.[j]

--- a/src/Fabulous/ArrayExtra.fs
+++ b/src/Fabulous/ArrayExtra.fs
@@ -1,0 +1,28 @@
+namespace Fabulous
+
+module Array =
+    let inline appendOne (v: 'v) (arr: 'v array) =
+        let res = Array.zeroCreate (arr.Length + 1)
+        Array.blit arr 0 res 0 arr.Length
+        res.[arr.Length] <- v
+        res
+
+    /// This is insertion sort that is O(n*n) but it performs better
+    /// 1. if the array is partially sorted (second sort is cheap)
+    /// 2. there are few elements, we expect to have only a handful of them per widget
+    /// 3. stable, which is handy for duplicate attributes, e.g. we can choose which one to pick
+    /// https://en.wikipedia.org/wiki/Insertion_sort
+    let inline sortInPlace<'T, 'V when 'V: comparison> ([<InlineIfLambda>] getKey: 'T -> 'V) (attrs: 'T []) : 'T [] =
+        let N = attrs.GetLength(0)
+
+        for i in [ 1 .. N - 1 ] do
+            for j = i downto 1 do
+                let key = getKey attrs.[j]
+                let prevKey = getKey (attrs.[j - 1])
+
+                if key < prevKey then
+                    let temp = attrs.[j]
+                    attrs.[j] <- attrs.[j - 1]
+                    attrs.[j - 1] <- temp
+
+        attrs

--- a/src/Fabulous/ArraySlice.fs
+++ b/src/Fabulous/ArraySlice.fs
@@ -1,0 +1,20 @@
+namespace Fabulous
+
+open System
+
+type ArraySlice<'v> = (struct (uint16 * 'v array))
+
+module ArraySlice =
+    let inline toSpan (a: ArraySlice<'v>) =
+        let struct (size, arr) = a
+        Span(arr, 0, int size)
+
+    let inline fromArrayOpt (arr: 'v [] option) : ArraySlice<'v> voption =
+        match arr with
+        | None -> ValueNone
+        | Some arr -> ValueSome(uint16 arr.Length, arr)
+
+    let inline fromArray (arr: 'v []) : ArraySlice<'v> voption =
+        match arr.Length with
+        | 0 -> ValueNone
+        | size -> ValueSome(uint16 size, arr)

--- a/src/Fabulous/ArraySlice.fs
+++ b/src/Fabulous/ArraySlice.fs
@@ -7,7 +7,12 @@ type ArraySlice<'v> = (struct (uint16 * 'v array))
 module ArraySlice =
     let inline toSpan (a: ArraySlice<'v>) =
         let struct (size, arr) = a
-        Span(arr, 0, int size)
+
+        match size with
+        | 0us -> Span.Empty
+        | size -> Span(arr, 0, int size)
+
+    let inline emptyWithNull () : ArraySlice<'v> = (0us, null) // note null in here
 
     let inline fromArrayOpt (arr: 'v [] option) : ArraySlice<'v> voption =
         match arr with

--- a/src/Fabulous/ArraySlice.fs
+++ b/src/Fabulous/ArraySlice.fs
@@ -18,3 +18,21 @@ module ArraySlice =
         match arr.Length with
         | 0 -> ValueNone
         | size -> ValueSome(uint16 size, arr)
+
+    let shiftByMut (slice: ArraySlice<'v> inref) (by: uint16) : 'v array =
+        let struct (used, arr) = slice
+
+        let used = int used
+        let by = int by
+
+        // noop if we don't have enough space
+        if (used + by <= arr.Length) then
+            for i = used + by - 1 downto int by do
+                arr.[i] <- arr.[i - by]
+
+        arr
+
+//    let test () =
+//        let slice = ArraySlice(2us, [| 1; 2; 0; 0 |])
+//        let arr = shiftByMut &slice 2us
+//        printfn "%A" arr

--- a/src/Fabulous/AttributeDefinitions.fs
+++ b/src/Fabulous/AttributeDefinitions.fs
@@ -84,10 +84,10 @@ type WidgetCollectionAttributeDefinition =
         Key: AttributeKey
         Name: string
         ApplyDiff: ArraySlice<WidgetCollectionItemChange> * IViewNode -> unit
-        UpdateNode: Widget [] voption * IViewNode -> unit
+        UpdateNode: ArraySlice<Widget> voption * IViewNode -> unit
     }
 
-    member x.WithValue(value: Widget []) : WidgetCollectionAttribute =
+    member x.WithValue(value: ArraySlice<Widget>) : WidgetCollectionAttribute =
         {
             Key = x.Key
 #if DEBUG
@@ -103,7 +103,7 @@ type WidgetCollectionAttributeDefinition =
             let newValueOpt =
                 match newValueOpt with
                 | ValueNone -> ValueNone
-                | ValueSome v -> ValueSome(unbox<Widget []> v)
+                | ValueSome v -> ValueSome(unbox<ArraySlice<Widget>> v)
 
             x.UpdateNode(newValueOpt, node)
 

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -100,15 +100,15 @@ module Attributes =
             let childNode = get node.Target
 
             match diff.ScalarChanges with
-            | Some changes -> childNode.ApplyScalarDiffs(changes)
-            | None -> ()
+            | ValueSome changes -> childNode.ApplyScalarDiffs(changes)
+            | ValueNone -> ()
 
             match diff.WidgetChanges with
-            | ValueSome slice -> childNode.ApplyWidgetDiffs(slice)
+            | ValueSome slice -> childNode.ApplyWidgetDiffs(ArraySlice.toSpan slice)
             | ValueNone -> ()
 
             match diff.WidgetCollectionChanges with
-            | ValueSome slice -> childNode.ApplyWidgetCollectionDiffs(slice)
+            | ValueSome slice -> childNode.ApplyWidgetCollectionDiffs(ArraySlice.toSpan slice)
             | ValueNone -> ()
 
         let updateNode (newValueOpt: Widget voption, node: IViewNode) =
@@ -143,15 +143,15 @@ module Attributes =
                         node.GetViewNodeForChild(targetColl.[index])
 
                     match widgetDiff.ScalarChanges with
-                    | Some changes -> childNode.ApplyScalarDiffs(changes)
-                    | None -> ()
+                    | ValueSome changes -> childNode.ApplyScalarDiffs(changes)
+                    | ValueNone -> ()
 
                     match widgetDiff.WidgetChanges with
-                    | ValueSome slice -> childNode.ApplyWidgetDiffs(slice)
+                    | ValueSome slice -> childNode.ApplyWidgetDiffs(ArraySlice.toSpan slice)
                     | ValueNone -> ()
 
                     match widgetDiff.WidgetCollectionChanges with
-                    | ValueSome slice -> childNode.ApplyWidgetCollectionDiffs(slice)
+                    | ValueSome slice -> childNode.ApplyWidgetCollectionDiffs(ArraySlice.toSpan slice)
                     | ValueNone -> ()
 
                 | WidgetCollectionItemChange.Replace (index, widget) ->

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -99,14 +99,17 @@ module Attributes =
         let applyDiff (diff: WidgetDiff, node: IViewNode) =
             let childNode = get node.Target
 
-            if diff.ScalarChanges.Length > 0 then
-                childNode.ApplyScalarDiffs(diff.ScalarChanges)
+            match diff.ScalarChanges with
+            | Some changes -> childNode.ApplyScalarDiffs(changes)
+            | None -> ()
 
-            if diff.WidgetChanges.Length > 0 then
-                childNode.ApplyWidgetDiffs(diff.WidgetChanges)
+            match diff.WidgetChanges with
+            | Some changes -> childNode.ApplyWidgetDiffs(changes)
+            | None -> ()
 
-            if diff.WidgetCollectionChanges.Length > 0 then
-                childNode.ApplyWidgetCollectionDiffs(diff.WidgetCollectionChanges)
+            match diff.WidgetCollectionChanges with
+            | Some changes -> childNode.ApplyWidgetCollectionDiffs(changes)
+            | None -> ()
 
         let updateNode (newValueOpt: Widget voption, node: IViewNode) =
             match newValueOpt with
@@ -139,14 +142,18 @@ module Attributes =
                     let childNode =
                         node.GetViewNodeForChild(targetColl.[index])
 
-                    if widgetDiff.ScalarChanges.Length > 0 then
-                        childNode.ApplyScalarDiffs(widgetDiff.ScalarChanges)
+                    match widgetDiff.ScalarChanges with
+                    | Some changes -> childNode.ApplyScalarDiffs(changes)
+                    | None -> ()
 
-                    if widgetDiff.WidgetChanges.Length > 0 then
-                        childNode.ApplyWidgetDiffs(widgetDiff.WidgetChanges)
+                    match widgetDiff.WidgetChanges with
+                    | Some changes -> childNode.ApplyWidgetDiffs(changes)
+                    | None -> ()
 
-                    if widgetDiff.WidgetCollectionChanges.Length > 0 then
-                        childNode.ApplyWidgetCollectionDiffs(widgetDiff.WidgetCollectionChanges)
+                    match widgetDiff.WidgetCollectionChanges with
+                    | Some changes -> childNode.ApplyWidgetCollectionDiffs(changes)
+                    | None -> ()
+
 
                 | WidgetCollectionItemChange.Replace (index, widget) ->
                     let view = Helpers.createViewForWidget node widget

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -79,7 +79,7 @@ module Attributes =
     let defineWidgetCollectionWithConverter
         name
         (applyDiff: ArraySlice<WidgetCollectionItemChange> * IViewNode -> unit)
-        (updateNode: Widget [] voption * IViewNode -> unit)
+        (updateNode: ArraySlice<Widget> voption * IViewNode -> unit)
         =
         let key = AttributeDefinitionStore.getNextKey()
 
@@ -160,14 +160,14 @@ module Attributes =
 
                 | _ -> ()
 
-        let updateNode (newValueOpt: Widget [] voption, node: IViewNode) =
+        let updateNode (newValueOpt: ArraySlice<Widget> voption, node: IViewNode) =
             let targetColl = getCollection node.Target
             targetColl.Clear()
 
             match newValueOpt with
             | ValueNone -> ()
             | ValueSome widgets ->
-                for widget in widgets do
+                for widget in ArraySlice.toSpan widgets do
                     let view = Helpers.createViewForWidget node widget
                     targetColl.Add(unbox view)
 

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -3,11 +3,12 @@ namespace Fabulous
 open System.ComponentModel
 open Fabulous
 open Fabulous.StackAllocatedCollections
+open Fabulous.StackAllocatedCollections.StackList
 open Microsoft.FSharp.Core
 
 
 type AttributesBundle =
-    (struct (StackArray3<ScalarAttribute> * WidgetAttribute [] option * WidgetCollectionAttribute [] option))
+    (struct (StackList<ScalarAttribute> * WidgetAttribute [] option * WidgetCollectionAttribute [] option))
 
 [<Struct; NoComparison; NoEquality>]
 type WidgetBuilder<'msg, 'marker> =
@@ -20,19 +21,19 @@ type WidgetBuilder<'msg, 'marker> =
         new(key: WidgetKey, scalar: ScalarAttribute) =
             {
                 Key = key
-                Attributes = AttributesBundle(StackArray3.one scalar, None, None)
+                Attributes = AttributesBundle(StackList.one scalar, None, None)
             }
 
         new(key: WidgetKey, scalarA: ScalarAttribute, scalarB: ScalarAttribute) =
             {
                 Key = key
-                Attributes = AttributesBundle(StackArray3.two(scalarA, scalarB), None, None)
+                Attributes = AttributesBundle(StackList.two(scalarA, scalarB), None, None)
             }
 
         new(key: WidgetKey, scalar1: ScalarAttribute, scalar2: ScalarAttribute, scalar3: ScalarAttribute) =
             {
                 Key = key
-                Attributes = AttributesBundle(StackArray3.three(scalar1, scalar2, scalar3), None, None)
+                Attributes = AttributesBundle(StackList.three(scalar1, scalar2, scalar3), None, None)
             }
 
         [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -45,9 +46,9 @@ type WidgetBuilder<'msg, 'marker> =
                 DebugName = $"{typeof<'marker>.Name}<{typeof<'msg>.Name}>"
 #endif
                 ScalarAttributes =
-                    match StackArray3.length &scalarAttributes with
-                    | 0 -> None
-                    | _ -> Some(Array.sortInPlace(fun a -> a.Key) (StackArray3.toArray &scalarAttributes))
+                    match StackList.length &scalarAttributes with
+                    | 0us -> None
+                    | _ -> Some(Array.sortInPlace(fun a -> a.Key) (StackList.toArray &scalarAttributes))
 
                 WidgetAttributes =
                     widgetAttributes
@@ -65,8 +66,23 @@ type WidgetBuilder<'msg, 'marker> =
 
             WidgetBuilder<'msg, 'marker>(
                 x.Key,
-                struct (StackArray3.add(&scalarAttributes, attr), widgetAttributes, widgetCollectionAttributes)
+                struct (StackList.add(&scalarAttributes, attr), widgetAttributes, widgetCollectionAttributes)
             )
+
+
+        //        [<EditorBrowsable(EditorBrowsableState.Never)>]
+//        member inline x.AddScalars(scalars: StackArray3<ScalarAttribute>) : WidgetBuilder<'msg, 'marker> =
+//            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
+//
+//            WidgetBuilder<'msg, 'marker>(
+//                x.Key,
+//                AttributesBundle(
+//                    StackArray3.combine scalarAttributes scalars,
+//                    widgetAttributes,
+//                    widgetCollectionAttributes
+//                )
+//            )
+
 
         [<EditorBrowsable(EditorBrowsableState.Never)>]
         member x.AddWidget(attr: WidgetAttribute) =
@@ -99,20 +115,8 @@ type WidgetBuilder<'msg, 'marker> =
                     attribs2
 
             WidgetBuilder<'msg, 'marker>(x.Key, struct (scalarAttributes, widgetAttributes, Some res))
-
-        [<EditorBrowsable(EditorBrowsableState.Never)>]
-        member inline x.AddScalars(scalars: StackArray3<ScalarAttribute>) : WidgetBuilder<'msg, 'marker> =
-            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
-
-            WidgetBuilder<'msg, 'marker>(
-                x.Key,
-                AttributesBundle(
-                    StackArray3.combine scalarAttributes scalars,
-                    widgetAttributes,
-                    widgetCollectionAttributes
-                )
-            )
     end
+
 
 
 [<Struct>]
@@ -122,10 +126,10 @@ type Content<'msg> = { Widgets: MutStackArray1.T<Widget> }
 type CollectionBuilder<'msg, 'marker, 'itemMarker> =
     struct
         val WidgetKey: WidgetKey
-        val Scalars: StackArray3<ScalarAttribute>
+        val Scalars: StackList<ScalarAttribute>
         val Attr: WidgetCollectionAttributeDefinition
 
-        new(widgetKey: WidgetKey, scalars: StackArray3<ScalarAttribute>, attr: WidgetCollectionAttributeDefinition) =
+        new(widgetKey: WidgetKey, scalars: StackList<ScalarAttribute>, attr: WidgetCollectionAttributeDefinition) =
             {
                 WidgetKey = widgetKey
                 Scalars = scalars
@@ -135,14 +139,14 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
         new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition) =
             {
                 WidgetKey = widgetKey
-                Scalars = StackArray3.empty()
+                Scalars = StackList.empty()
                 Attr = attr
             }
 
         new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalar: ScalarAttribute) =
             {
                 WidgetKey = widgetKey
-                Scalars = StackArray3.one scalar
+                Scalars = StackList.one scalar
                 Attr = attr
             }
 
@@ -152,7 +156,7 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
             scalarB: ScalarAttribute) =
             {
                 WidgetKey = widgetKey
-                Scalars = StackArray3.two(scalarA, scalarB)
+                Scalars = StackList.two(scalarA, scalarB)
                 Attr = attr
             }
 

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -105,7 +105,7 @@ type WidgetBuilder<'msg, 'marker> =
             WidgetBuilder<'msg, 'marker>(x.Key, struct (scalarAttributes, widgetAttributes, Some res))
 
         [<EditorBrowsable(EditorBrowsableState.Never)>]
-        member x.AddScalars(attrs: ScalarAttribute []) =
+        member x.AddScalars(attrs: ScalarAttribute []) : WidgetBuilder<'msg, 'marker> =
             let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
             //        if attrs.Length = 0 then
             //            x

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -6,16 +6,16 @@ open Fabulous.StackAllocatedCollections
 open Microsoft.FSharp.Core
 
 
-type AttributesInFlight =
+type AttributesBundle =
     (struct (StackArray3<ScalarAttribute> * WidgetAttribute [] option * WidgetCollectionAttribute [] option))
 
-[<Struct>]
+[<Struct; NoComparison; NoEquality>]
 type WidgetBuilder<'msg, 'marker> =
     struct
         val Key: WidgetKey
-        val Attributes: AttributesInFlight
+        val Attributes: AttributesBundle
 
-        new(key: WidgetKey, attributes: AttributesInFlight) = { Key = key; Attributes = attributes }
+        new(key: WidgetKey, attributes: AttributesBundle) = { Key = key; Attributes = attributes }
 
         new(key: WidgetKey, scalar: ScalarAttribute) =
             {
@@ -27,6 +27,12 @@ type WidgetBuilder<'msg, 'marker> =
             {
                 Key = key
                 Attributes = struct (StackArray3.two(scalarA, scalarB), None, None)
+            }
+
+        new(key: WidgetKey, scalar1: ScalarAttribute, scalar2: ScalarAttribute, scalar3: ScalarAttribute) =
+            {
+                Key = key
+                Attributes = struct (StackArray3.three(scalar1, scalar2, scalar3), None, None)
             }
 
         [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -136,6 +142,30 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
             {
                 WidgetKey = widgetKey
                 Scalars = scalars
+                Attr = attr
+            }
+
+        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition) =
+            {
+                WidgetKey = widgetKey
+                Scalars = StackArray3.empty()
+                Attr = attr
+            }
+
+        new(widgetKey: WidgetKey, attr: WidgetCollectionAttributeDefinition, scalar: ScalarAttribute) =
+            {
+                WidgetKey = widgetKey
+                Scalars = StackArray3.one scalar
+                Attr = attr
+            }
+
+        new(widgetKey: WidgetKey,
+            attr: WidgetCollectionAttributeDefinition,
+            scalarA: ScalarAttribute,
+            scalarB: ScalarAttribute) =
+            {
+                WidgetKey = widgetKey
+                Scalars = StackArray3.two(scalarA, scalarB)
                 Attr = attr
             }
 

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -140,10 +140,12 @@ type CollectionBuilder<'msg, 'marker, 'itemMarker> =
             }
 
         member inline x.Run(c: Content<'msg>) =
-            WidgetBuilder<'msg, 'marker>(
-                x.WidgetKey,
-                struct (x.Scalars, None, Some [| x.Attr.WithValue(MutStackArray1.toArray &c.Widgets) |])
-            )
+            let attrValue =
+                match MutStackArray1.toArraySlice &c.Widgets with
+                | ValueNone -> ArraySlice.emptyWithNull()
+                | ValueSome slice -> slice
+
+            WidgetBuilder<'msg, 'marker>(x.WidgetKey, struct (x.Scalars, None, Some [| x.Attr.WithValue(attrValue) |]))
 
         member inline _.Combine(a: Content<'msg>, b: Content<'msg>) : Content<'msg> =
             let res =
@@ -176,7 +178,12 @@ type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker> =
             { Widget = widget; Attr = attr }
 
         member inline x.Run(c: Content<'msg>) =
-            x.Widget.AddWidgetCollection(x.Attr.WithValue(MutStackArray1.toArray &c.Widgets))
+            let attrValue =
+                match MutStackArray1.toArraySlice &c.Widgets with
+                | ValueNone -> ArraySlice.emptyWithNull()
+                | ValueSome slice -> slice
+
+            x.Widget.AddWidgetCollection(x.Attr.WithValue(attrValue))
 
         member inline _.Combine(a: Content<'msg>, b: Content<'msg>) : Content<'msg> =
             {

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -2,139 +2,186 @@ namespace Fabulous
 
 open System.ComponentModel
 open Fabulous
+open Fabulous.StackAllocatedCollections
 open Microsoft.FSharp.Core
 
+
+type AttributesInFlight =
+    (struct (StackArray3<ScalarAttribute> * WidgetAttribute [] option * WidgetCollectionAttribute [] option))
+
 [<Struct>]
-type WidgetBuilder<'msg, 'marker>
-    (
-        key: WidgetKey,
-        attributes: struct (ScalarAttribute [] * WidgetAttribute [] * WidgetCollectionAttribute [])
-    ) =
-    
-    member _.Key = key
-    member _.Attributes = attributes
+type WidgetBuilder<'msg, 'marker> =
+    struct
+        val Key: WidgetKey
+        val Attributes: AttributesInFlight
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    member _.Compile() : Widget =
-        let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = attributes
+        new(key: WidgetKey, attributes: AttributesInFlight) = { Key = key; Attributes = attributes }
 
-        {
-            Key = key
+
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member x.Compile() : Widget =
+            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
+
+            {
+                Key = x.Key
 #if DEBUG
-            DebugName = $"{typeof<'marker>.Name}<{typeof<'msg>.Name}>"
+                DebugName = $"{typeof<'marker>.Name}<{typeof<'msg>.Name}>"
 #endif
-            ScalarAttributes = scalarAttributes
-            WidgetAttributes = widgetAttributes
-            WidgetCollectionAttributes = widgetCollectionAttributes
-        }
+                ScalarAttributes =
+                    match StackArray3.length &scalarAttributes with
+                    | 0 -> None
+                    | _ -> Some(Array.sortInPlace(fun a -> a.Key) (StackArray3.toArray &scalarAttributes))
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    member _.AddScalar(attr: ScalarAttribute) =
-        let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = attributes
-        let attribs = scalarAttributes
-        let attribs2 = Array.zeroCreate(attribs.Length + 1)
-        Array.blit attribs 0 attribs2 0 attribs.Length
-        attribs2.[attribs.Length] <- attr
+                WidgetAttributes =
+                    widgetAttributes
+                    |> Option.map(Array.sortInPlace(fun a -> a.Key))
 
-        WidgetBuilder<'msg, 'marker>(key, struct (attribs2, widgetAttributes, widgetCollectionAttributes))
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    member _.AddWidget(attr: WidgetAttribute) =
-        let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = attributes
-        let attribs = widgetAttributes
-        let attribs2 = Array.zeroCreate(attribs.Length + 1)
-        Array.blit attribs 0 attribs2 0 attribs.Length
-        attribs2.[attribs.Length] <- attr
+                WidgetCollectionAttributes =
+                    widgetCollectionAttributes
+                    |> Option.map(Array.sortInPlace(fun a -> a.Key))
+            }
 
-        WidgetBuilder<'msg, 'marker>(key, struct (scalarAttributes, attribs2, widgetCollectionAttributes))
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member inline x.AddScalar(attr: ScalarAttribute) =
+            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
+            //        let attribs = scalarAttributes
+            //        let attribs2 = Array.zeroCreate(attribs.Length + 1)
+            //        Array.blit attribs 0 attribs2 0 attribs.Length
+            //        attribs2.[attribs.Length] <- attr
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    member _.AddWidgetCollection(attr: WidgetCollectionAttribute) =
-        let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = attributes
-        let attribs = widgetCollectionAttributes
-        let attribs2 = Array.zeroCreate(attribs.Length + 1)
-        Array.blit attribs 0 attribs2 0 attribs.Length
-        attribs2.[attribs.Length] <- attr
+            WidgetBuilder<'msg, 'marker>(
+                x.Key,
+                struct (StackArray3.add(&scalarAttributes, attr), widgetAttributes, widgetCollectionAttributes)
+            )
 
-        WidgetBuilder<'msg, 'marker>(key, struct (scalarAttributes, widgetAttributes, attribs2))
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member x.AddWidget(attr: WidgetAttribute) =
+            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
+            let attribs = widgetAttributes
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    member x.AddScalars(attrs: ScalarAttribute []) =
-        if attrs.Length = 0 then
-            x
-        else
-            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = attributes
-            let attribs = scalarAttributes
+            let res =
+                match attribs with
+                | None -> [| attr |]
+                | Some attribs ->
+                    let attribs2 = Array.zeroCreate(attribs.Length + 1)
+                    Array.blit attribs 0 attribs2 0 attribs.Length
+                    attribs2.[attribs.Length] <- attr
+                    attribs2
 
-            let attribs2 =
-                Array.zeroCreate(attribs.Length + attrs.Length)
+            WidgetBuilder<'msg, 'marker>(x.Key, struct (scalarAttributes, Some res, widgetCollectionAttributes))
 
-            Array.blit attribs 0 attribs2 0 attribs.Length
-            Array.blit attrs 0 attribs2 attribs.Length attrs.Length
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member x.AddWidgetCollection(attr: WidgetCollectionAttribute) =
+            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
+            let attribs = widgetCollectionAttributes
 
-            WidgetBuilder<'msg, 'marker>(key, struct (attribs2, widgetAttributes, widgetCollectionAttributes))
+            let res =
+                match attribs with
+                | None -> [| attr |]
+                | Some attribs ->
+                    let attribs2 = Array.zeroCreate(attribs.Length + 1)
+                    Array.blit attribs 0 attribs2 0 attribs.Length
+                    attribs2.[attribs.Length] <- attr
+                    attribs2
+
+            WidgetBuilder<'msg, 'marker>(x.Key, struct (scalarAttributes, widgetAttributes, Some res))
+
+        [<EditorBrowsable(EditorBrowsableState.Never)>]
+        member x.AddScalars(attrs: ScalarAttribute []) =
+            let struct (scalarAttributes, widgetAttributes, widgetCollectionAttributes) = x.Attributes
+            //        if attrs.Length = 0 then
+            //            x
+            //        else
+            //            let attribs = scalarAttributes
+            //
+            //            let attribs2 =
+            //                Array.zeroCreate(attribs.Length + attrs.Length)
+            //
+            //            Array.blit attribs 0 attribs2 0 attribs.Length
+            //            Array.blit attrs 0 attribs2 attribs.Length attrs.Length
+            // TODO
+            failwith "TODO"
+    end
+
+//        let t = (StackArray3.fromArray attrs)
+//
+//        let newScalars =
+//            StackArray3.combine(&scalarAttributes, &t)
+//
+//        WidgetBuilder<'msg, 'marker>(key, struct (newScalars, widgetAttributes, widgetCollectionAttributes))
 
 [<Struct>]
-type Content<'msg> = { Widgets: Widget list }
+type Content<'msg> = { Widgets: StackArray3<Widget> }
 
 [<Struct>]
-type CollectionBuilder<'msg, 'marker, 'itemMarker>
-    (
-        widgetKey: WidgetKey,
-        scalars: ScalarAttribute [] voption,
-        attr: WidgetCollectionAttributeDefinition
-    ) =
+type CollectionBuilder<'msg, 'marker, 'itemMarker> =
+    struct
+        val WidgetKey: WidgetKey
+        val Scalars: StackArray3<ScalarAttribute>
+        val Attr: WidgetCollectionAttributeDefinition
 
-    member _.Run(c: Content<'msg>) =
-        WidgetBuilder<'msg, 'marker>(
-            widgetKey,
-            struct (match scalars with
-                    | ValueNone -> [||]
-                    | ValueSome s -> s
-                    , [||]
-                    , [|
-                        attr.WithValue(List.toArray c.Widgets)
-                    |])
-        )
+        new(widgetKey: WidgetKey, scalars: StackArray3<ScalarAttribute>, attr: WidgetCollectionAttributeDefinition) =
+            {
+                WidgetKey = widgetKey
+                Scalars = scalars
+                Attr = attr
+            }
 
-    member inline _.Combine(a: Content<'msg>, b: Content<'msg>) : Content<'msg> = { Widgets = a.Widgets @ b.Widgets }
+        member inline x.Run(c: Content<'msg>) =
+            WidgetBuilder<'msg, 'marker>(
+                x.WidgetKey,
+                struct (x.Scalars, None, Some [| x.Attr.WithValue(StackArray3.toArray &c.Widgets) |])
+            )
 
-    member inline _.Zero() : Content<'msg> = { Widgets = [] }
+        member inline _.Combine(a: Content<'msg>, b: Content<'msg>) : Content<'msg> =
+            {
+                Widgets = StackArray3.combine a.Widgets b.Widgets
+            }
 
-    member inline _.Delay([<InlineIfLambda>] f) : Content<'msg> = f()
+        member inline _.Zero() : Content<'msg> = { Widgets = StackArray3.empty() }
 
-    member inline x.For<'t>(sequence: 't seq, [<InlineIfLambda>] f: 't -> Content<'msg>) : Content<'msg> =
-        let mutable res: Content<'msg> = x.Zero()
+        member inline _.Delay([<InlineIfLambda>] f) : Content<'msg> = f()
 
-        // this is essentially Fold, not sure what is more optimal
-        // handwritten version of via Seq.Fold
-        for t in sequence do
-            res <- x.Combine(res, f t)
+        member inline x.For<'t>(sequence: 't seq, [<InlineIfLambda>] f: 't -> Content<'msg>) : Content<'msg> =
+            let mutable res: Content<'msg> = x.Zero()
 
-        res
-        
+            // this is essentially Fold, not sure what is more optimal
+            // handwritten version of via Seq.Fold
+            for t in sequence do
+                res <- x.Combine(res, f t)
+
+            res
+    end
+
 [<Struct>]
-type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker>
-    (
-        widget: WidgetBuilder<'msg, 'marker>,
-        attr: WidgetCollectionAttributeDefinition
-    ) =
+type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker> =
+    struct
+        val Widget: WidgetBuilder<'msg, 'marker>
+        val Attr: WidgetCollectionAttributeDefinition
 
-    member _.Run(c: Content<'msg>) =
-        widget.AddWidgetCollection(attr.WithValue(List.toArray c.Widgets))
+        new(widget: WidgetBuilder<'msg, 'marker>, attr: WidgetCollectionAttributeDefinition) =
+            { Widget = widget; Attr = attr }
 
-    member inline _.Combine(a: Content<'msg>, b: Content<'msg>) : Content<'msg> = { Widgets = a.Widgets @ b.Widgets }
+        member inline x.Run(c: Content<'msg>) =
+            x.Widget.AddWidgetCollection(x.Attr.WithValue(StackArray3.toArray &c.Widgets))
 
-    member inline _.Zero() : Content<'msg> = { Widgets = [] }
+        member inline _.Combine(a: Content<'msg>, b: Content<'msg>) : Content<'msg> =
+            {
+                Widgets = StackArray3.combine a.Widgets b.Widgets
+            }
 
-    member inline _.Delay([<InlineIfLambda>] f) : Content<'msg> = f()
+        member inline _.Zero() : Content<'msg> = { Widgets = StackArray3.empty() }
 
-    member inline x.For<'t>(sequence: 't seq, [<InlineIfLambda>] f: 't -> Content<'msg>) : Content<'msg> =
-        let mutable res: Content<'msg> = x.Zero()
+        member inline _.Delay([<InlineIfLambda>] f) : Content<'msg> = f()
 
-        // this is essentially Fold, not sure what is more optimal
-        // handwritten version of via Seq.Fold
-        for t in sequence do
-            res <- x.Combine(res, f t)
+        member inline x.For<'t>(sequence: 't seq, [<InlineIfLambda>] f: 't -> Content<'msg>) : Content<'msg> =
+            let mutable res: Content<'msg> = x.Zero()
 
-        res
+            // this is essentially Fold, not sure what is more optimal
+            // handwritten version of via Seq.Fold
+            for t in sequence do
+                res <- x.Combine(res, f t)
+
+            res
+    end

--- a/src/Fabulous/Core.fs
+++ b/src/Fabulous/Core.fs
@@ -49,7 +49,7 @@ and [<Struct>] WidgetCollectionAttribute =
 #if DEBUG
         DebugName: string
 #endif
-        Value: Widget []
+        Value: ArraySlice<Widget>
     }
 
 /// Represents a virtual UI element such as a Label, a Button, etc.

--- a/src/Fabulous/Core.fs
+++ b/src/Fabulous/Core.fs
@@ -1,5 +1,6 @@
 ﻿namespace Fabulous
 
+open System
 open System.Collections.Generic
 
 /// Dev notes:
@@ -59,9 +60,9 @@ and [<Struct>] Widget =
 #if DEBUG
         DebugName: string
 #endif
-        ScalarAttributes: ScalarAttribute [] option
-        WidgetAttributes: WidgetAttribute [] option
-        WidgetCollectionAttributes: WidgetCollectionAttribute [] option
+        ScalarAttributes: ScalarAttribute [] voption
+        WidgetAttributes: WidgetAttribute [] voption
+        WidgetCollectionAttributes: WidgetCollectionAttribute [] voption
     }
 
 [<Struct; RequireQualifiedAccess>]
@@ -89,7 +90,7 @@ and [<Struct; RequireQualifiedAccess>] WidgetCollectionItemChange =
 
 and [<Struct; NoComparison; NoEquality>] WidgetDiff =
     {
-        ScalarChanges: ScalarChange [] option
+        ScalarChanges: ScalarChange [] voption
         WidgetChanges: ArraySlice<WidgetChange> voption
         WidgetCollectionChanges: ArraySlice<WidgetCollectionChange> voption
     }
@@ -117,5 +118,5 @@ and IViewNode =
     abstract member TryGetHandler<'T> : AttributeKey -> 'T voption
     abstract member SetHandler<'T> : AttributeKey * 'T voption -> unit
     abstract member ApplyScalarDiffs : ScalarChange [] -> unit
-    abstract member ApplyWidgetDiffs : ArraySlice<WidgetChange> -> unit
-    abstract member ApplyWidgetCollectionDiffs : ArraySlice<WidgetCollectionChange> -> unit
+    abstract member ApplyWidgetDiffs : Span<WidgetChange> -> unit
+    abstract member ApplyWidgetCollectionDiffs : Span<WidgetCollectionChange> -> unit

--- a/src/Fabulous/Core.fs
+++ b/src/Fabulous/Core.fs
@@ -19,6 +19,7 @@ type WidgetKey = int
 type StateKey = int
 type ViewAdapterKey = int
 
+
 /// Represents a value for a property of a widget.
 /// Can map to a real property (such as Label.Text) or to a non-existent one.
 /// It will be up to the AttributeDefinition to decide how to apply the value.
@@ -31,6 +32,7 @@ type ScalarAttribute =
 #endif
         Value: obj
     }
+
 
 and [<Struct>] WidgetAttribute =
     {
@@ -77,7 +79,7 @@ and [<Struct; RequireQualifiedAccess>] WidgetChange =
 and [<Struct; RequireQualifiedAccess>] WidgetCollectionChange =
     | Added of added: WidgetCollectionAttribute
     | Removed of removed: WidgetCollectionAttribute
-    | Updated of updated: struct (WidgetCollectionAttribute * WidgetCollectionItemChange [])
+    | Updated of updated: struct (WidgetCollectionAttribute * ArraySlice<WidgetCollectionItemChange>)
 
 and [<Struct; RequireQualifiedAccess>] WidgetCollectionItemChange =
     | Insert of widgetInserted: struct (int * Widget)
@@ -85,11 +87,11 @@ and [<Struct; RequireQualifiedAccess>] WidgetCollectionItemChange =
     | Update of widgetUpdated: struct (int * WidgetDiff)
     | Remove of removed: int
 
-and [<Struct>] WidgetDiff =
+and [<Struct; NoComparison; NoEquality>] WidgetDiff =
     {
         ScalarChanges: ScalarChange [] option
-        WidgetChanges: WidgetChange [] option
-        WidgetCollectionChanges: WidgetCollectionChange [] option
+        WidgetChanges: ArraySlice<WidgetChange> voption
+        WidgetCollectionChanges: ArraySlice<WidgetCollectionChange> voption
     }
 
 /// Context of the whole view tree
@@ -115,5 +117,5 @@ and IViewNode =
     abstract member TryGetHandler<'T> : AttributeKey -> 'T voption
     abstract member SetHandler<'T> : AttributeKey * 'T voption -> unit
     abstract member ApplyScalarDiffs : ScalarChange [] -> unit
-    abstract member ApplyWidgetDiffs : WidgetChange [] -> unit
-    abstract member ApplyWidgetCollectionDiffs : WidgetCollectionChange [] -> unit
+    abstract member ApplyWidgetDiffs : ArraySlice<WidgetChange> -> unit
+    abstract member ApplyWidgetCollectionDiffs : ArraySlice<WidgetCollectionChange> -> unit

--- a/src/Fabulous/Core.fs
+++ b/src/Fabulous/Core.fs
@@ -57,9 +57,9 @@ and [<Struct>] Widget =
 #if DEBUG
         DebugName: string
 #endif
-        ScalarAttributes: ScalarAttribute []
-        WidgetAttributes: WidgetAttribute []
-        WidgetCollectionAttributes: WidgetCollectionAttribute []
+        ScalarAttributes: ScalarAttribute [] option
+        WidgetAttributes: WidgetAttribute [] option
+        WidgetCollectionAttributes: WidgetCollectionAttribute [] option
     }
 
 [<Struct; RequireQualifiedAccess>]
@@ -87,9 +87,9 @@ and [<Struct; RequireQualifiedAccess>] WidgetCollectionItemChange =
 
 and [<Struct>] WidgetDiff =
     {
-        ScalarChanges: ScalarChange []
-        WidgetChanges: WidgetChange []
-        WidgetCollectionChanges: WidgetCollectionChange []
+        ScalarChanges: ScalarChange [] option
+        WidgetChanges: WidgetChange [] option
+        WidgetCollectionChanges: WidgetCollectionChange [] option
     }
 
 /// Context of the whole view tree

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -1,27 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Include="StackAllocatedCollections.fs"/>
-        <None Include="PackageREADME.md" Pack="true" PackagePath="\"/>
-        <Compile Include="Core.fs"/>
-        <Compile Include="AttributeDefinitions.fs"/>
-        <Compile Include="WidgetDefinitions.fs"/>
-        <Compile Include="Builders.fs"/>
-        <Compile Include="Reconciler.fs"/>
-        <Compile Include="ViewNode.fs"/>
-        <Compile Include="State.fs"/>
-        <Compile Include="Cmd.fs"/>
-        <Compile Include="Runners.fs"/>
-        <Compile Include="Memo.fs"/>
-        <Compile Include="Attributes.fs"/>
-        <Compile Include="MapMsg.fs"/>
-        <Compile Include="ViewNamespace.fs"/>
+        <None Include="PackageREADME.md" Pack="true" PackagePath="\" />
+        <Compile Include="ArrayExtra.fs" />
+        <Compile Include="StackAllocatedCollections.fs" />
+        <Compile Include="Core.fs" />
+        <Compile Include="AttributeDefinitions.fs" />
+        <Compile Include="WidgetDefinitions.fs" />
+        <Compile Include="Builders.fs" />
+        <Compile Include="Reconciler.fs" />
+        <Compile Include="ViewNode.fs" />
+        <Compile Include="State.fs" />
+        <Compile Include="Cmd.fs" />
+        <Compile Include="Runners.fs" />
+        <Compile Include="Memo.fs" />
+        <Compile Include="Attributes.fs" />
+        <Compile Include="MapMsg.fs" />
+        <Compile Include="ViewNamespace.fs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="6.0.1"/>
+        <PackageReference Update="FSharp.Core" Version="6.0.1" />
+        <PackageReference Include="System.Memory" Version="4.5.3" />
     </ItemGroup>
 </Project>

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -5,25 +5,26 @@
         <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
-        <None Include="PackageREADME.md" Pack="true" PackagePath="\" />
-        <Compile Include="ArrayExtra.fs" />
-        <Compile Include="StackAllocatedCollections.fs" />
-        <Compile Include="Core.fs" />
-        <Compile Include="AttributeDefinitions.fs" />
-        <Compile Include="WidgetDefinitions.fs" />
-        <Compile Include="Builders.fs" />
-        <Compile Include="Reconciler.fs" />
-        <Compile Include="ViewNode.fs" />
-        <Compile Include="State.fs" />
-        <Compile Include="Cmd.fs" />
-        <Compile Include="Runners.fs" />
-        <Compile Include="Memo.fs" />
-        <Compile Include="Attributes.fs" />
-        <Compile Include="MapMsg.fs" />
-        <Compile Include="ViewNamespace.fs" />
+        <None Include="PackageREADME.md" Pack="true" PackagePath="\"/>
+        <Compile Include="ArraySlice.fs"/>
+        <Compile Include="ArrayExtra.fs"/>
+        <Compile Include="StackAllocatedCollections.fs"/>
+        <Compile Include="Core.fs"/>
+        <Compile Include="AttributeDefinitions.fs"/>
+        <Compile Include="WidgetDefinitions.fs"/>
+        <Compile Include="Builders.fs"/>
+        <Compile Include="Reconciler.fs"/>
+        <Compile Include="ViewNode.fs"/>
+        <Compile Include="State.fs"/>
+        <Compile Include="Cmd.fs"/>
+        <Compile Include="Runners.fs"/>
+        <Compile Include="Memo.fs"/>
+        <Compile Include="Attributes.fs"/>
+        <Compile Include="MapMsg.fs"/>
+        <Compile Include="ViewNamespace.fs"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="6.0.1" />
-        <PackageReference Include="System.Memory" Version="4.5.3" />
+        <PackageReference Update="FSharp.Core" Version="6.0.1"/>
+        <PackageReference Include="System.Memory" Version="4.5.3"/>
     </ItemGroup>
 </Project>

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -29,10 +29,9 @@ module Memo =
     let internal MemoWidgetKey = WidgetDefinitionStore.getNextKey()
 
     let inline private getMemoData (widget: Widget) : MemoData =
-        match widget.ScalarAttributes.Length with
-        | 1 -> widget.ScalarAttributes.[0].Value :?> MemoData
+        match widget.ScalarAttributes with
+        | ValueSome attrs when attrs.Length = 1 -> attrs.[0].Value :?> MemoData
         | _ -> failwith "Memo widget cannot have extra attributes"
-
 
     let internal canReuseMemoizedWidget prev next =
         (getMemoData prev).MarkerType = (getMemoData next).MarkerType

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -6,13 +6,13 @@ module Memo =
 
     type internal MemoData =
         {
-            /// Captures type of data that memoization depends on
+            /// Captures data that memoization depends on
             KeyData: obj
 
             // comparer that remembers KeyType internally
             KeyComparer: obj -> obj -> bool
 
-            /// Lambda that users provide
+            /// wrapped untyped lambda that users provide
             CreateWidget: obj -> Widget
 
             /// Captures type hash of data that memoization depends on
@@ -28,8 +28,7 @@ module Memo =
     let internal MemoWidgetKey = WidgetDefinitionStore.getNextKey()
 
     let inline private getMemoData (widget: Widget) : MemoData =
-        (widget.ScalarAttributes
-         |> Array.find(fun a -> a.Key = MemoAttributeKey))
+        (Array.find(fun (a: ScalarAttribute) -> a.Key = MemoAttributeKey) (Option.get widget.ScalarAttributes))
             .Value
         :?> MemoData
 

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -28,7 +28,7 @@ module Memo =
     let internal MemoWidgetKey = WidgetDefinitionStore.getNextKey()
 
     let inline private getMemoData (widget: Widget) : MemoData =
-        (Array.find(fun (a: ScalarAttribute) -> a.Key = MemoAttributeKey) (Option.get widget.ScalarAttributes))
+        (Array.find(fun (a: ScalarAttribute) -> a.Key = MemoAttributeKey) (ValueOption.get widget.ScalarAttributes))
             .Value
         :?> MemoData
 

--- a/src/Fabulous/Reconciler.fs
+++ b/src/Fabulous/Reconciler.fs
@@ -213,10 +213,12 @@ module Reconciler =
             prev
             |> Array.map WidgetCollectionChange.Removed
             |> ArraySlice.fromArray
+
         | None, Some next ->
             next
             |> Array.map WidgetCollectionChange.Added
             |> ArraySlice.fromArray
+
         | Some prev, Some next ->
 
             let mutable result = MutStackArray1.Empty

--- a/src/Fabulous/Reconciler.fs
+++ b/src/Fabulous/Reconciler.fs
@@ -95,7 +95,7 @@ module Reconciler =
                         | ScalarAttributeComparison.Identical -> ()
 
                         // New value completely replaces the old value
-                        | ScalarAttributeComparison.Different value ->
+                        | ScalarAttributeComparison.Different ->
                             DiffBuilder.addOpMut &result DiffBuilder.Change (uint16 nextIndex)
 
                         // move both pointers

--- a/src/Fabulous/StackAllocatedCollections.fs
+++ b/src/Fabulous/StackAllocatedCollections.fs
@@ -95,10 +95,10 @@ module StackList =
                     arr
 
             static member add(data: StackList<'v> inref, v: 'v) =
-                let lenght = data.size
+                let length = data.size
                 let struct (v0, v1, _) = data.items
 
-                match lenght with
+                match length with
                 | 0us -> StackList.one v
                 | 1us -> StackList.two(v0, v)
                 | 2us -> StackList.three(v0, v1, v)
@@ -447,6 +447,7 @@ module MutStackArray1 =
 open FSharp.NativeInterop
 
 #nowarn "9"
+
 let inline stackalloc<'a when 'a: unmanaged> (length: int) : Span<'a> =
     let p =
         NativePtr.stackalloc<'a> length

--- a/src/Fabulous/StackAllocatedCollections.fs
+++ b/src/Fabulous/StackAllocatedCollections.fs
@@ -446,6 +446,7 @@ module MutStackArray1 =
 
 open FSharp.NativeInterop
 
+#nowarn "9"
 let inline stackalloc<'a when 'a: unmanaged> (length: int) : Span<'a> =
     let p =
         NativePtr.stackalloc<'a> length

--- a/src/Fabulous/StackAllocatedCollections.fs
+++ b/src/Fabulous/StackAllocatedCollections.fs
@@ -26,10 +26,6 @@ module StackList =
         | Empty
         | Filled of struct (Items<'v> * Part<'v>)
 
-    module private Part =
-        let inline combine (before: Part<'v>, after: Part<'v>) : Part<'v> = Empty
-
-
     [<Struct; NoComparison; NoEquality>]
     type StackList<'v> =
         struct
@@ -106,47 +102,17 @@ module StackList =
                 | 0us -> StackList.one v
                 | 1us -> StackList.two(v0, v)
                 | 2us -> StackList.three(v0, v1, v)
-                | size when size % 3us = 0us -> StackList(size + 1us, Items.one v, Filled(data.items, data.before))
-                // still filling up the stack allocated part
-                | size when size % 3us = 1us -> StackList(size + 1us, Items.two(v0, v), data.before)
-                | size when size % 3us = 2us -> StackList(size + 1us, Items(v0, v1, v), data.before)
-                | _ -> data // should never happen but let's not throw there
+                | size ->
+                    match size % 3us with
+                    | 0us -> StackList(size + 1us, Items.one v, Filled(data.items, data.before))
+
+                    // still filling up the stack allocated part
+                    // 1 item filled
+                    | 1us -> StackList(size + 1us, Items.two(v0, v), data.before)
+
+                    // 2 items filled
+                    | _ -> StackList(size + 1us, Items(v0, v1, v), data.before)
         end
-
-
-//            static member combine (a: Data<'v>) (b: Data<'v>) : Data<'v> =
-//                let lenghtA = a.length
-//                let lenghtB = a.length
-//                let struct (a0, a1, _) = a.items
-//                let struct (b0, b1, _) = b.items
-//
-//                match lenghtA, lenghtB with
-//                | 0us, _ -> b
-//                | _, 0us -> a
-//                | 1us, 1us -> Data.two(a0, b0)
-//                | 2us, 1us -> Data.three(a0, a1, b0)
-//                | 1us, 2us -> Data.three(a0, b0, b1)
-//                | la, lb ->
-//                    let leftOverA = lenghtA % 3us
-//                    let leftOverB = lenghtB % 3us
-//
-//                    // note that lenghtA and lenghtB are >= 3 each
-//                    match leftOverA, leftOverB with
-//                    | 0us, _ ->
-//                        // means that "a" items are filled
-//                        Data(lenghtA + lenghtB, b.items, Part.combine(Filled(a.items, a.before), b.before))
-//
-//                    | _, 0us -> a
-//
-//                    | 1us, 1us -> Data.two(a0, b0)
-//                    | 2us, 1us -> Data.three(a0, a1, b0)
-//                    | 1us, 2us -> Data.three(a0, b0, b1)
-
-
-//                | size when size % 3us = 0us -> Data(size + 1us, Items.one v, Some(Chunk(data.items, data.before)))
-//                | size when size % 3us = 1us -> Data(size + 1us, Items.two(v0, v), Some(Chunk(data.items, data.before)))
-//                | size when size % 3us = 2us -> Data(size + 1us, Items(v0, v1, v), Some(Chunk(data.items, data.before)))
-//                | _ -> data // should never happen but let's not throw there
 
 
 

--- a/src/Fabulous/StackAllocatedCollections.fs
+++ b/src/Fabulous/StackAllocatedCollections.fs
@@ -1,132 +1,324 @@
 module Fabulous.StackAllocatedCollections
 
-module Array =
-    let inline appendOne (v: 'v) (arr: 'v array) =
-        let res = Array.zeroCreate(arr.Length + 1)
-        Array.blit arr 0 res 0 arr.Length
-        res.[arr.Length] <- v
-        res
+open System
+open System.Collections.Generic
+open System.Runtime.CompilerServices
+
 
 
 //let a = Array.length [||]
 //[<System.Runtime.CompilerServices.IsReadOnly>]
-type StackArray3<'v> = (struct (int * 'v * 'v * 'v * 'v array))
 
-//    struct
-//        val count: int
-//        val v0: 'v
-//        val v1: 'v
-//        val v2: 'v
-//        val rest: 'v array
-//
-//        new(count: int, v0: 'v, v1: 'v, v2: 'v, rest: 'v array) =
-//            {
-//                count = count
-//                v0 = v0
-//                v1 = v1
-//                v2 = v2
-//                rest = rest
-//            }
-//    end
 
+type Size =
+    | Zero = 0uy
+    | One = 1uy
+    | Two = 2uy
+    | Three = 3uy
+
+
+[<Struct; NoComparison>]
+type StackArray3<'v> =
+    | Few of data: struct (Size * 'v * 'v * 'v)
+    | Many of arr: 'v array
 
 module StackArray3 =
 
     let inline empty () : StackArray3<'v> =
-        //        let t = StackArray3 ()
-//        t.count <- 2
-
-        StackArray3(
-            0,
-            Unchecked.defaultof<'v>,
-            Unchecked.defaultof<'v>,
-            Unchecked.defaultof<'v>,
-            Unchecked.defaultof<'v array>
-        )
-
-    // t
+        Few(Size.Zero, Unchecked.defaultof<'v>, Unchecked.defaultof<'v>, Unchecked.defaultof<'v>)
 
     let inline one (v0: 'v) : StackArray3<'v> =
-        StackArray3(1, v0, Unchecked.defaultof<'v>, Unchecked.defaultof<'v>, Unchecked.defaultof<'v array>)
+        Few(Size.One, v0, Unchecked.defaultof<'v>, Unchecked.defaultof<'v>)
 
     let inline two (v0: 'v, v1: 'v) : StackArray3<'v> =
-        StackArray3(2, v0, v1, Unchecked.defaultof<'v>, Unchecked.defaultof<'v array>)
+        Few(Size.Two, v0, v1, Unchecked.defaultof<'v>)
 
-    let inline three (v0: 'v, v1: 'v, v2: 'v) : StackArray3<'v> =
-        StackArray3(3, v0, v1, v2, Unchecked.defaultof<'v array>)
+    let inline three (v0: 'v, v1: 'v, v2: 'v) : StackArray3<'v> = Few(Size.Three, v0, v1, v2)
 
-    let inline many (v0: 'v, v1: 'v, v2: 'v, rest: 'v array) : StackArray3<'v> =
-        StackArray3(3 + rest.Length, v0, v1, v2, rest)
+    let inline many (arr: 'v array) : StackArray3<'v> = Many arr
 
-    let inline add (arr: StackArray3<'v>, v: 'v) : StackArray3<'v> =
-        let struct (count, v0, v1, v2, rest) = arr
-        match count with
-        | 0 -> one(v)
-        | 1 -> two(v0, v)
-        | 2 -> three(v0, v1, v)
-        | 3 -> many(v0, v1, v2, [| v |])
-        | _ -> many(v0, v1, v2, Array.appendOne v rest)
+    let add (arr: StackArray3<'v> inref, v: 'v) : StackArray3<'v> =
+        match arr with
+        | Few (struct (size, v0, v1, v2)) ->
+            match size with
+            | Size.Zero -> one(v)
+            | Size.One -> two(v0, v)
+            | Size.Two -> three(v0, v1, v)
+            | Size.Three -> many([| v0; v1; v2; v |])
+            | _ -> empty() // should never happen but don't want to throw there
+        | Many arr -> many(Array.appendOne v arr)
 
-    let inline a0 () = [||]
-    let inline a1 (v: 'v) = [| v |]
-    let inline a2 (v0: 'v, v1: 'v) = [| v0; v1 |]
-    let inline a3 (v0: 'v, v1: 'v, v2: 'v) = [| v0; v1; v2 |]
 
-    let inline an (v0: 'v, v1: 'v, v2: 'v, rest: 'v array) =
-        let a = Array.create<'v> (rest.Length + 3) v0
-//        a[ 0 ] <- v0
-        a[ 1 ] <- v1
-        a[ 2 ] <- v2
+    let inline length (arr: StackArray3<'v> inref) : int =
+        match arr with
+        | Few (struct (size, _, _, _)) -> int size
+        | Many arr -> arr.Length
 
-        Array.blit rest 0 a 3 rest.Length
-        //            Array.append [| arr.v0; arr.v1; arr.v2 |] arr.rest
-        a
 
-    let inline toArray (arr: StackArray3<'v> inref) : 'v array =
-        let struct (count, v0, v1, v2, rest) = arr
-        match count with
-        | 0 -> a0()
-        | 1 -> a1(v0)
-        | 2 -> a2(v0, v1)
-        | 3 -> a3(v0, v1, v2)
-        | _ -> an(v0, v1, v2, rest)
+    let get (arr: StackArray3<'v> inref) (index: int) : 'v =
+        match arr with
+        | Few (struct (size, v0, v1, v2)) ->
+            if (index >= int size) then
+                IndexOutOfRangeException() |> raise
+            else
+                match index with
+                | 0 -> v0
+                | 1 -> v1
+                | _ -> v2
 
-    //    let toArray (arr: StackArray3<'v>) : 'v array =
-//        match arr.count with
-//        | 0 -> [||]
-//        | 1 -> [| arr.v0 |]
-//        | 2 -> [| arr.v0; arr.v1 |]
-//        | 3 -> [| arr.v0; arr.v1; arr.v2 |]
-//        | _ ->
-//            let a = Array.zeroCreate<'v> arr.count
-//            a[0] <- arr.v0
-//            a[1] <- arr.v1
-//            a[2] <- arr.v2
-//
-//            Array.blit arr.rest 0 a 3 arr.rest.Length
-//            a
+        | Many arr -> arr.[index]
 
-    let inline fromArray (arr: 'v array) : StackArray3<'v> =
-       match arr.Length with
-       | 0 -> empty()
-       | 1 -> one(arr[0])
-       | 2 -> two(arr[0], arr[1])
-       | 3 -> three(arr[0], arr[1], arr[2])
-       | _ -> many(arr[0], arr[1], arr[2], Array.skip 3 arr)
 
-    let inline combine (a: StackArray3<'v> inref, b: StackArray3<'v> inref) : StackArray3<'v> =
-        let struct (acount, av0, av1, av2, arest) = a
-        let struct (bcount, bv0, bv1, bv2, brest) = b
-        match (acount, bcount) with
-        | 0, _ -> b
-        | _, 0 -> a
-        | _, 1 -> add(a, bv0)
-        | 1, 2 -> three(av0, bv0, bv1)
-        | 1, 3 -> many(av0, bv0, bv1, [| bv2 |])
-        | 1, _ -> many(av0, bv0, bv1, Array.append [| bv2 |] brest) // TODO
-        | 2, 2 -> many(av0, av1, bv0, [| bv1 |])
-        | 2, 3 -> many(av0, av1, bv0, [| bv1; bv2 |])
-        | 2, _ -> many(av0, av1, bv0, Array.append [| bv1; bv2 |] brest) // TODO
-        | 3, 2 -> many(av0, av1, av2, [| bv0; bv1 |])
-        | 3, _ -> many(av0, av1, av2, (toArray &b))
-        | _ -> many(av0, av1, av2, Array.append arest (toArray &b)) // TODO
+    let find (test: 'v -> bool) (arr: StackArray3<'v> inref) : 'v =
+        match arr with
+        | Few (struct (size, v0, v1, v2)) ->
+            match (size, test v0, test v1, test v2) with
+            | (Size.One, true, _, _)
+            | (Size.Two, true, _, _)
+            | (Size.Three, true, _, _) -> v0
+            | (Size.Two, false, true, _)
+            | (Size.Three, false, true, _) -> v1
+            | (Size.Three, false, false, true) -> v2
+            | _ -> KeyNotFoundException() |> raise
+        | Many arr -> Array.find test arr
+
+
+    /// Note that you should always use the result,
+    /// In Few mode it creates a new stack allocated array
+    /// In Many case it sorts the Many variant inline for optimization reasons
+    let rec inline sortInPlace<'T, 'V when 'V: comparison>
+        ([<InlineIfLambda>] getKey: 'T -> 'V)
+        (arr: StackArray3<'T> inref)
+        : StackArray3<'T> =
+        match arr with
+        | Few (struct (size, v0, v1, v2)) ->
+            match size with
+            | Size.Zero
+            | Size.One -> arr
+            | Size.Two ->
+                if (getKey v0 > getKey v1) then
+                    two(v1, v0)
+                else
+                    arr
+            | Size.Three ->
+                match (getKey v0, getKey v1, getKey v1) with
+                // abc acb bac bca cba cab
+
+                //  a, c, b
+                | (a, b, c) when a <= c && c <= b -> three(v0, v2, v1)
+
+                //  b, a, c
+                | (a, b, c) when b <= a && a <= c -> three(v1, v0, v2)
+
+                //  b, c, a
+                | (a, b, c) when b <= c && c <= a -> three(v1, v2, v0)
+
+                //  c, b, a
+                | (a, b, c) when c <= b && b <= a -> three(v2, v1, v0)
+
+                //  c, a, b
+                | (a, b, c) when c <= a && a <= b -> three(v2, v0, v1)
+
+                // a, b, c left, thus already sorted
+                | _ -> arr
+
+
+            | _ -> empty() // should never happen but don't want to throw there
+        | Many arr -> many(Array.sortInPlace getKey arr)
+
+
+    let inline private arr0 () = [||]
+    let inline private arr1 (v: 'v) = [| v |]
+    let inline private arr2 (v0: 'v, v1: 'v) = [| v0; v1 |]
+    let inline private arr3 (v0: 'v, v1: 'v, v2: 'v) = [| v0; v1; v2 |]
+
+    let toArray (arr: StackArray3<'v> inref) : 'v array =
+        match arr with
+        | Few (struct (size, v0, v1, v2)) ->
+            match size with
+            | Size.Zero -> Array.empty
+            | Size.One -> arr1 v0
+            | Size.Two -> arr2(v0, v1)
+            | _ -> arr3(v0, v1, v2)
+        | Many arr -> arr
+
+
+    let combine (a: StackArray3<'v>) (b: StackArray3<'v>) : StackArray3<'v> =
+        match (a, b) with
+        | (Few (struct (asize, a0, a1, a2)), Few (struct (bsize, b0, b1, b2))) ->
+            match (asize, bsize) with
+            | Size.Zero, _ -> b
+            | _, Size.Zero -> a
+            | Size.One, Size.One -> two(a0, b0)
+            | Size.One, Size.Two -> three(a0, b0, b1)
+            | Size.Two, Size.One -> three(a0, a1, b0)
+            // now many cases
+            | Size.One, Size.Three -> many([| a0; b0; b1; b2 |])
+            | Size.Three, Size.One -> many([| a0; a1; a2; b0 |])
+            | Size.Two, Size.Two -> many([| a0; a1; b0; b1 |])
+            | Size.Three, Size.Two -> many([| a0; a1; a2; b0; b1 |])
+            | Size.Two, Size.Three -> many([| a0; a1; b0; b1; b2 |])
+            | Size.Three, Size.Three -> many([| a0; a1; a2; b0; b1; b2 |])
+            | _ -> a // this should never happen because we exhausted all the other cases
+        | Few _, Many arr2 -> many(Array.append(toArray &a) arr2) // TODO optimize
+        | Many arr1, Few _ -> many(Array.append arr1 (toArray &b)) // TODO optimize
+        | Many arr1, Many arr2 -> many(Array.append arr1 arr2)
+
+
+
+
+
+
+module MutStackArray1 =
+
+    [<IsByRefLike; Struct>]
+    type T<'v> =
+        | Empty
+        | One of one: 'v
+        | Many of struct (uint16 * 'v [])
+
+    let addMut (arr: T<'v> inref, value: 'v) : T<'v> =
+        match arr with
+        | Empty -> One value
+        | One v ->
+            Many
+                struct (2us,
+                        [|
+                            v
+                            value
+                            Unchecked.defaultof<'v>
+                            Unchecked.defaultof<'v>
+                        |])
+        | Many struct (count, mutArr) ->
+            if mutArr.Length > (int count) then
+                // we can fit it in
+                mutArr.[int count] <- value
+                Many(count + 1us, mutArr)
+            else
+                // in this branch we reached the capacity of the array, thus needs to grow
+                let countInt = int count
+
+                let res =
+                    // count is at least 2
+                    // thus it is either going to grow at least by 1
+                    // note that the growth rate is slower than ResizeArray
+                    Array.zeroCreate(max((countInt * 2) / 3) countInt + 1)
+
+                Array.blit mutArr 0 res 0 mutArr.Length
+                res.[countInt] <- value
+                Many(count + 1us, res)
+
+    let toArray (arr: T<'v> inref) : 'v array =
+        match arr with
+        | Empty -> Array.empty
+        | One v -> [| v |]
+        | Many (struct (count, arr)) -> Array.take(int count) arr
+
+    let inline length (arr: T<'v> inref) : int =
+        match arr with
+        | Empty -> 0
+        | One v -> 1
+        | Many (struct (count, _)) -> int count
+
+open FSharp.NativeInterop
+
+let inline stackalloc<'a when 'a: unmanaged> (length: int) : Span<'a> =
+    let p =
+        NativePtr.stackalloc<'a> length
+        |> NativePtr.toVoidPtr
+
+    Span<'a>(p, length)
+
+//let t = stackalloc<uint16>(3)
+
+
+
+[<IsByRefLike>]
+type DiffBuilder =
+    struct
+        val ops: Span<uint16>
+        val mutable cursor: int
+        val mutable rest: uint16 array
+
+        new(span: Span<uint16>, cursor) =
+            {
+                ops = span // stackalloc<uint16>(capacity)
+                cursor = cursor
+                rest = null
+            }
+    end
+
+
+
+
+module DiffBuilder =
+    // 2 bytes
+    type OpType =
+        | Add // 1
+        | Remove // 2
+        | Change // 3
+
+    // 00 is omitted on purpose for debuggability
+
+    module OpCode =
+        [<Literal>]
+        let AddCode = 1us
+
+        [<Literal>]
+        let RemoveCode = 2us
+
+        [<Literal>]
+        let ChangeCode = 3us
+
+
+    [<Struct>]
+    type Op =
+        | Added of added: uint16
+        | Removed of removed: uint16
+        | Changed of changed: uint16
+
+
+    let inline create () = DiffBuilder(stackalloc<uint16>(8), 0)
+
+    // reserve 2bits for op
+    let valueMask = UInt16.MaxValue >>> 2
+
+    // two left bits for op
+    let opMask = UInt16.MaxValue ^^^ valueMask
+
+    // TODO handle growth
+    let addOpMut (builder: DiffBuilder byref) (op: OpType) (index: uint16) =
+        let op =
+            match op with
+            | Add -> OpCode.AddCode
+            | Remove -> OpCode.RemoveCode
+            | Change -> OpCode.ChangeCode
+
+        let encodedValue = ((uint16 op <<< 14) &&& opMask)
+        let encodedValue = encodedValue ||| (index &&& valueMask)
+
+        builder.ops.[builder.cursor] <- encodedValue
+        builder.cursor <- builder.cursor + 1
+
+
+    let inline lenght (builder: DiffBuilder byref) = builder.cursor
+
+    let inline private decode (encodedValue: uint16) : Op =
+        let op = encodedValue >>> 14
+
+        let value = encodedValue &&& valueMask
+
+        match op with
+        | OpCode.AddCode -> Added(value)
+        | OpCode.RemoveCode -> Removed(value)
+        | OpCode.ChangeCode -> Changed(value)
+        | _ -> IndexOutOfRangeException() |> raise
+
+    let inline toArray (builder: DiffBuilder byref) (map: Op -> 't) : 't array =
+        let len = lenght &builder
+        let res = Array.zeroCreate<'t> len
+
+        for i = 0 to len - 1 do
+            res.[i] <- map(decode builder.ops.[i])
+
+        res

--- a/src/Fabulous/StackAllocatedCollections.fs
+++ b/src/Fabulous/StackAllocatedCollections.fs
@@ -73,12 +73,12 @@ module StackArray3 =
         match arr with
         | Few (struct (size, v0, v1, v2)) ->
             match (size, test v0, test v1, test v2) with
-            | (Size.One, true, _, _)
-            | (Size.Two, true, _, _)
-            | (Size.Three, true, _, _) -> v0
-            | (Size.Two, false, true, _)
-            | (Size.Three, false, true, _) -> v1
-            | (Size.Three, false, false, true) -> v2
+            | Size.One, true, _, _
+            | Size.Two, true, _, _
+            | Size.Three, true, _, _ -> v0
+            | Size.Two, false, true, _
+            | Size.Three, false, true, _ -> v1
+            | Size.Three, false, false, true -> v2
             | _ -> KeyNotFoundException() |> raise
         | Many arr -> Array.find test arr
 
@@ -105,19 +105,19 @@ module StackArray3 =
                 // abc acb bac bca cba cab
 
                 //  a, c, b
-                | (a, b, c) when a <= c && c <= b -> three(v0, v2, v1)
+                | a, b, c when a <= c && c <= b -> three(v0, v2, v1)
 
                 //  b, a, c
-                | (a, b, c) when b <= a && a <= c -> three(v1, v0, v2)
+                | a, b, c when b <= a && a <= c -> three(v1, v0, v2)
 
                 //  b, c, a
-                | (a, b, c) when b <= c && c <= a -> three(v1, v2, v0)
+                | a, b, c when b <= c && c <= a -> three(v1, v2, v0)
 
                 //  c, b, a
-                | (a, b, c) when c <= b && b <= a -> three(v2, v1, v0)
+                | a, b, c when c <= b && b <= a -> three(v2, v1, v0)
 
                 //  c, a, b
-                | (a, b, c) when c <= a && a <= b -> three(v2, v0, v1)
+                | a, b, c when c <= a && a <= b -> three(v2, v0, v1)
 
                 // a, b, c left, thus already sorted
                 | _ -> arr
@@ -213,6 +213,12 @@ module MutStackArray1 =
         | Empty -> Array.empty
         | One v -> [| v |]
         | Many (struct (count, arr)) -> Array.take(int count) arr
+
+    let toArraySlice (arr: T<'v> inref) : ArraySlice<'v> voption =
+        match arr with
+        | Empty -> ValueNone
+        | One v -> ValueSome(1us, [| v |])
+        | Many slice -> ValueSome slice
 
     let inline length (arr: T<'v> inref) : int =
         match arr with

--- a/src/Fabulous/StackAllocatedCollections.fs
+++ b/src/Fabulous/StackAllocatedCollections.fs
@@ -10,6 +10,146 @@ open System.Runtime.CompilerServices
 //[<System.Runtime.CompilerServices.IsReadOnly>]
 
 
+module StackList =
+    type private Items<'v> = (struct ('v * 'v * 'v))
+
+    module private Items =
+        let inline one<'v> (v: 'v) =
+            Items(v, Unchecked.defaultof<'v>, Unchecked.defaultof<'v>)
+
+        let inline two<'v> (v1: 'v, v2: 'v) = Items(v1, v2, Unchecked.defaultof<'v>)
+
+    /// reference type that holds the chain of tuples that come before Data
+    /// this is basically List
+    [<NoComparison; NoEquality>]
+    type private Part<'v> =
+        | Empty
+        | Filled of struct (Items<'v> * Part<'v>)
+
+    module private Part =
+        let inline combine (before: Part<'v>, after: Part<'v>) : Part<'v> = Empty
+
+
+    [<Struct; NoComparison; NoEquality>]
+    type StackList<'v> =
+        struct
+            val private size: uint16
+            val private items: Items<'v>
+            val private before: Part<'v>
+
+            private new(size, items, before) =
+                {
+                    size = size
+                    items = items
+                    before = before
+                }
+
+            static member empty() =
+                StackList(0us, Unchecked.defaultof<Items<'v>>, Empty)
+
+            static member one(v: 'v) = StackList(1us, Items.one v, Empty)
+
+            static member two(v1: 'v, v2: 'v) =
+                StackList(2us, Items.two(v1, v2), Empty)
+
+            static member three(v1: 'v, v2: 'v, v3: 'v) =
+                StackList(3us, Items(v1, v2, v3), Empty)
+
+            static member length(data: StackList<'v> inref) = data.size
+
+            static member toArray(data: StackList<'v> inref) : 'v array =
+                if data.size = 0us then
+                    Array.empty
+                else
+                    let size = int data.size
+                    let arr = Array.zeroCreate(size)
+                    let struct (v0, v1, v2) = data.items
+
+                    let used =
+                        match data.size % 3us with
+                        | 0us -> // copy 3 items
+                            arr.[size - 1] <- v2
+                            arr.[size - 2] <- v1
+                            arr.[size - 3] <- v0
+                            3
+                        | 1us ->
+                            // copy 1 item
+                            arr.[size - 1] <- v0
+                            1
+                        | 2us ->
+                            // copy 2 item
+                            arr.[size - 1] <- v1
+                            arr.[size - 2] <- v0
+                            2
+                        | _ -> 0
+
+                    let mutable i = size - used - 1
+                    let mutable leftToCopy = data.before
+
+                    while i >= 2 do
+                        match leftToCopy with
+                        | Empty -> i <- -1
+                        | Filled ((v0, v1, v2), before) ->
+                            arr.[i] <- v2
+                            arr.[i - 1] <- v1
+                            arr.[i - 2] <- v0
+                            i <- i - 3
+                            leftToCopy <- before
+
+                    arr
+
+            static member add(data: StackList<'v> inref, v: 'v) =
+                let lenght = data.size
+                let struct (v0, v1, _) = data.items
+
+                match lenght with
+                | 0us -> StackList.one v
+                | 1us -> StackList.two(v0, v)
+                | 2us -> StackList.three(v0, v1, v)
+                | size when size % 3us = 0us -> StackList(size + 1us, Items.one v, Filled(data.items, data.before))
+                // still filling up the stack allocated part
+                | size when size % 3us = 1us -> StackList(size + 1us, Items.two(v0, v), data.before)
+                | size when size % 3us = 2us -> StackList(size + 1us, Items(v0, v1, v), data.before)
+                | _ -> data // should never happen but let's not throw there
+        end
+
+
+//            static member combine (a: Data<'v>) (b: Data<'v>) : Data<'v> =
+//                let lenghtA = a.length
+//                let lenghtB = a.length
+//                let struct (a0, a1, _) = a.items
+//                let struct (b0, b1, _) = b.items
+//
+//                match lenghtA, lenghtB with
+//                | 0us, _ -> b
+//                | _, 0us -> a
+//                | 1us, 1us -> Data.two(a0, b0)
+//                | 2us, 1us -> Data.three(a0, a1, b0)
+//                | 1us, 2us -> Data.three(a0, b0, b1)
+//                | la, lb ->
+//                    let leftOverA = lenghtA % 3us
+//                    let leftOverB = lenghtB % 3us
+//
+//                    // note that lenghtA and lenghtB are >= 3 each
+//                    match leftOverA, leftOverB with
+//                    | 0us, _ ->
+//                        // means that "a" items are filled
+//                        Data(lenghtA + lenghtB, b.items, Part.combine(Filled(a.items, a.before), b.before))
+//
+//                    | _, 0us -> a
+//
+//                    | 1us, 1us -> Data.two(a0, b0)
+//                    | 2us, 1us -> Data.three(a0, a1, b0)
+//                    | 1us, 2us -> Data.three(a0, b0, b1)
+
+
+//                | size when size % 3us = 0us -> Data(size + 1us, Items.one v, Some(Chunk(data.items, data.before)))
+//                | size when size % 3us = 1us -> Data(size + 1us, Items.two(v0, v), Some(Chunk(data.items, data.before)))
+//                | size when size % 3us = 2us -> Data(size + 1us, Items(v0, v1, v), Some(Chunk(data.items, data.before)))
+//                | _ -> data // should never happen but let's not throw there
+
+
+
 type Size =
     | Zero = 0uy
     | One = 1uy

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -28,7 +28,7 @@ module View =
 
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(
             Memo.MemoWidgetKey,
-            struct ([| Memo.MemoAttribute.WithValue(memo) |], [||], [||])
+            Memo.MemoAttribute.WithValue(memo)
         )
 
     let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =

--- a/src/Fabulous/ViewNamespace.fs
+++ b/src/Fabulous/ViewNamespace.fs
@@ -1,5 +1,7 @@
 namespace Fabulous
 
+open Fabulous.StackAllocatedCollections
+
 
 
 module View =
@@ -19,7 +21,7 @@ module View =
 
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(
             Memo.MemoWidgetKey,
-            struct ([| Memo.MemoAttribute.WithValue(memo) |], [||], [||])
+            struct (StackArray3.one(Memo.MemoAttribute.WithValue(memo)), None, None)
         )
 
     let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =

--- a/src/Fabulous/ViewNamespace.fs
+++ b/src/Fabulous/ViewNamespace.fs
@@ -1,6 +1,7 @@
 namespace Fabulous
 
 open Fabulous.StackAllocatedCollections
+open Fabulous.StackAllocatedCollections.StackList
 
 
 
@@ -21,7 +22,7 @@ module View =
 
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(
             Memo.MemoWidgetKey,
-            struct (StackArray3.one(Memo.MemoAttribute.WithValue(memo)), None, None)
+            struct (StackList.one(Memo.MemoAttribute.WithValue(memo)), None, None)
         )
 
     let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =

--- a/src/Fabulous/ViewNamespace.fs
+++ b/src/Fabulous/ViewNamespace.fs
@@ -22,7 +22,7 @@ module View =
 
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(
             Memo.MemoWidgetKey,
-            struct (StackList.one(Memo.MemoAttribute.WithValue(memo)), None, None)
+            struct (StackList.one(Memo.MemoAttribute.WithValue(memo)), ValueNone, ValueNone)
         )
 
     let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -64,7 +64,7 @@ type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targe
             if not targetRef.IsAlive then
                 ()
             else
-                for diff in diffs do
+                for diff in ArraySlice.toSpan diffs do
                     match diff with
                     | WidgetChange.Added newWidget
                     | WidgetChange.ReplacedBy newWidget ->
@@ -89,7 +89,7 @@ type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targe
             if not targetRef.IsAlive then
                 ()
             else
-                for diff in diffs do
+                for diff in ArraySlice.toSpan diffs do
                     match diff with
                     | WidgetCollectionChange.Added added ->
                         let definition =

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -64,7 +64,7 @@ type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targe
             if not targetRef.IsAlive then
                 ()
             else
-                for diff in ArraySlice.toSpan diffs do
+                for diff in diffs do
                     match diff with
                     | WidgetChange.Added newWidget
                     | WidgetChange.ReplacedBy newWidget ->
@@ -89,7 +89,7 @@ type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targe
             if not targetRef.IsAlive then
                 ()
             else
-                for diff in ArraySlice.toSpan diffs do
+                for diff in diffs do
                     match diff with
                     | WidgetCollectionChange.Added added ->
                         let definition =


### PR DESCRIPTION
Note depends on #36
fixes: https://github.com/TimLariviere/Fabulous-new/issues/17

## Motivation

One of the goals of Fabulous is to be **fast**, in other words, produce minimal amount of overhead on top of underlying UI Framework (like XF or MAUI).

The way I see it we need to optimize 3 things:
1. An API that allows to stop diffing sub trees, the attempt to cover that is #36
2. A very efficient way to create Widget UI trees
3. A very efficient way to calculate and apply diff of prev vs next Widget UI trees

This PR is mostly concerned with 2 and 3
___

## Approach

1. Allocate less
2. Take advantage of Comp Expression needed for building children and diffing to be internal details of the framework.
3. Use mutable data structures for things that are not observable to a user (such as diffing and CE) and use immutable optimized data structures that can be poked by a user.
4. Utilize stack allocated collections and data structures whenever makes sense

___

## What is done

### Stack allocated collections

**`MutStackArray1`**
* Holds one value on the stack (only allocates for 2+ items)
* Can be merged with another `MutStackArray1`, in that case both arrays are considered to be "consumed"
* Intended to be used for internal things only, although it kinda leaks a bit when you need to declare `Yield` extension to work with Computation Expressions
* Currently used inside CollectionBuilder for children and in Reconciler
* As a consequence of using mutable resizable array as a backing data structure we don't have precise control of the size of the array, therefore there is a need to introduce a new data structures that is a tuple of `(usedElmCount, array)`

**`ArraySlice`**
* Is exactly that `(usedElmCount, array)`
* Often a result of `MutStackArray1`
* Expressed as `struct (uint16, array<'T>)`

**`DiffBuilder`**
* Very niche data structure used for ScalarAttribute diffing
* The basic idea is to allocate on the **stack**  an array of `uint16` via `stackalloc` of fixed sized (8)
* encodes a sequence of  operation + index, `(add | remove | change * index)` , where operation is encoded into 2 bits and 14 is reserved for the index
* Allocates dynamically on the heap more space if needed, the idea is to no to use this branch in 99,999% of the cases. Potentially we can easily allocate on the stack up to 12-16 elements. I thought 8 is a reasonable starting point
* When  the diffing is done it produced the final heap allocated array with diffs,  the assumption that in most cases attribute diffing won’t produce a diff, thus avoids allocations entirely in majority of the cases

**`StackArray3`**
* An array like data structure that allocates 3 elements on the stack or 4+ on the heap.
* Immutable
* Was the first implementation I tried for attribute storage for Widgets
* Discovered a better alternative (`StackList`)
* **currently not used**

**`StackList`**
* An F# List like data structure 
* Immutable
* Optimized for adding to the end (vs beginning of F# List)
* Allocates 3 elements on the stack and then allocates a chunk that contains 3 elements when grows.
* Example: Adding consequently `1, 2, 3, 4`  to an empty `StackList` will result in 
	*  `Stack: 1`
	*  `Stack: 1, 2`
	*  `Stack: 1, 2, 3`
	*  `Heap: (1, 2, 3), Stack: 4`  <— fist allocation
	* Next allocation will be when adding the 7th element
* Used for `WidgetBuilder` for storing Scalar attributes. The assumption that most Widgets won’t have more that 3 scalars most of the time, and the ones that do will allocate just 1-2 times (at 4th and 7th elements respectively)
* Can be used for user facing things (Like WidgetBuilders)

### Usage summary 
* `StackList`  in  `WidgetBuilder`
* `DiffBuilder` for diffing scalar attributes
* `MutStackArray1`  in `CollectionBuilder`, `AttributeCollectionBuilder` and the rest of the diffing in Reconciler
* `StackArray3` currently not used because it is inferior to `StackList`

### Other changes
* `Widget`,  `WidgetDiff` now have either `voption` or `option` as fields to avoid allocations
* In Reconciler diffing code is mostly preserved but optimized for allocations.
	* Minor example: `Array.tryFind` allocates an `Option` if it holds a value type (structs), replaced with handwritten check
* `WidgetBuilder` now has many constructors that mostly replace `ViewHelper` functions needed for that
* Adjusted examples and Xamarin.Forms code accordingly (such as using `MutStackArray1` in `Yield`)
	* We might want to hide that under a helper method and make `MutStackArray1` ctor  `internal` for safety reasons.  Although tricky with CE inlining
* `ArraySlice` is now widely used, often in combination with `MutStackArray1`  as an output (for example in Reconciler)
___

## Benchmark
Finally the numbers!

Not only the diffing got significantly faster but now it allocates almost %50 less memory. 

Note that the memory numbers below are taken with a different growth function. Now the growth rate of `MutStackArray1` is 1.5 (note that it is less than `ResizeArray`), it is possible that we should be even more conservative and use `1.3` because most of our collections are small.

### Summary 

`ProcessMessages` benchmark

Before
```
depth: 10
time: 183.9 ms
memory: 222 MB

---

depth: 15
time: 3,332.6 ms 
memory: 2,472 MB
```

After
```
depth: 10
time: 146.4 ms (-37.5 ms)
memory: 127 MB (-96 MB)

---

depth: 15
time: 2,941.6 ms (-391 ms)
memory: 1,412 MB (-1060 MB)
```



### On main branch

|          Method | depth |       Mean |    Error |   StdDev |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|---------------- |------ |-----------:|---------:|---------:|------------:|------------:|-----------:|----------:|
| ProcessMessages |    10 |   183.9 ms |  3.53 ms |  3.93 ms |  68333.3333 |  16000.0000 |  3333.3333 |    222 MB |
| ProcessMessages |    15 | 3,332.6 ms | 50.03 ms | 44.35 ms | 759000.0000 | 178000.0000 | 78000.0000 |  2,472 MB |

### After these changes

|          Method | depth |       Mean |    Error |   StdDev |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|---------------- |------ |-----------:|---------:|---------:|------------:|------------:|-----------:|----------:|
| ProcessMessages |    10 |   146.4 ms |  2.11 ms |  1.97 ms |  43250.0000 |  17000.0000 |  1500.0000 |    127 MB |
| ProcessMessages |    15 | 2,941.6 ms | 49.67 ms | 46.46 ms | 460000.0000 | 166000.0000 | 67000.0000 |  1,412 MB |
