### PR TITLE
Add minimal GitHub Actions for building projects

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,27 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build Fabulous
+      run: dotnet build --no-restore src/Fabulous/Fabulous.fsproj
+    - name: Build Fabulous.XamarinForms
+      run: dotnet build --no-restore src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+    - name: Test Fabulous
+      run: dotnet test --no-build --verbosity normal src/Fabulous.Tests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Build Fabulous.XamarinForms
       run: dotnet build --no-restore src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
     - name: Build Fabulous.Tests
-      run: dotnet build --no-build --verbosity normal src/Fabulous.Tests
+      run: dotnet build --no-restore src/Fabulous.Tests/Fabulous.Tests.fsproj
     - name: Test Fabulous.Tests
-      run: dotnet test --no-build --verbosity normal src/Fabulous.Tests
+      run: dotnet test --no-build --verbosity normal src/Fabulous.Tests/Fabulous.Tests.fsproj

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,5 +23,7 @@ jobs:
       run: dotnet build --no-restore src/Fabulous/Fabulous.fsproj
     - name: Build Fabulous.XamarinForms
       run: dotnet build --no-restore src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
-    - name: Test Fabulous
+    - name: Build Fabulous.Tests
+      run: dotnet build --no-build --verbosity normal src/Fabulous.Tests
+    - name: Test Fabulous.Tests
       run: dotnet test --no-build --verbosity normal src/Fabulous.Tests


### PR DESCRIPTION
In order to help us catch mistakes faster, I've setup a very minimal Continuous Integration to build Fabulous, Fabulous.XamarinForms and run the tests in Fabulous.Tests on each PR and commits on main.

Later, we'll be able to add a full CI/CD building the samples, releasing the preview packages to GitHub Packages and the release ones to NuGet.

Would be nice to run Fabulous.Benchmarks also as part of CI to catch perf regressions but I'm not sure about the consistency of GitHub Actions build agents