### PR TITLE
Add image extensions based on the specification

### DIFF
--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/AboutPage.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/AboutPage.fs
@@ -63,7 +63,7 @@ module AboutPage =
             Label(Strings.AboutPage_AboutFSharp_MadeWith)
 
             (VStack() {
-                Image("fsharp.png", Aspect.AspectFit)
+                Image(Aspect.AspectFit, "fsharp.png")
                     .size (height = 50., width = 50.)
 
                 Label(Strings.AboutPage_AboutFSharp_FSharp)
@@ -72,7 +72,7 @@ module AboutPage =
                 .gestureRecognizers () { TapGestureRecognizer(openBrowser fsharpOrgUrl) }
 
             (VStack() {
-                Image("xamarin.png", Aspect.AspectFit)
+                Image(Aspect.AspectFit, "xamarin.png")
                     .size (height = 50., width = 50.)
 
                 Label(Strings.AboutPage_AboutFSharp_FabulousXamarinForms)
@@ -107,7 +107,7 @@ module AboutPage =
             Label(Strings.AboutPage_AboutAuthor_AuthorName)
 
             (HStack(spacing = 15.) {
-                Image("blog.png", Aspect.AspectFit)
+                Image(Aspect.AspectFit, "blog.png")
                     .size (height = 35., width = 35.)
 
                 UnderlinedLabel(authorBlogUrl).centerVertical ()
@@ -118,7 +118,7 @@ module AboutPage =
                 .margin (Thickness(0., 10., 0., 0.))
 
             (HStack(spacing = 15.) {
-                Image("github.png", Aspect.AspectFit)
+                Image(Aspect.AspectFit, "github.png")
                     .size (height = 35., width = 35.)
 
                 UnderlinedLabel(authorGitHubHandle)
@@ -128,7 +128,7 @@ module AboutPage =
 
             (HStack(spacing = 15.) {
                 (VStack() {
-                    Image("twitter.png", Aspect.AspectFit)
+                    Image(Aspect.AspectFit, "twitter.png")
                         .size (height = 50., width = 50.)
 
                     Label(authorTwitterHandle).centerTextHorizontal ()
@@ -136,7 +136,7 @@ module AboutPage =
                     .gestureRecognizers () { TapGestureRecognizer(openBrowser authorTwitterUrl) }
 
                 (VStack() {
-                    Image("slack.png", Aspect.AspectFit)
+                    Image(Aspect.AspectFit, "slack.png")
                         .size (height = 50., width = 50.)
 
                     Label(authorSlackHandle).centerTextHorizontal ()
@@ -152,7 +152,7 @@ module AboutPage =
             "About FabulousContacts",
             ScrollView(
                 (VStack() {
-                    ContentView(Image("icon.png", Aspect.AspectFit))
+                    ContentView(Image(Aspect.AspectFit, "icon.png"))
                         .backgroundColor(accentColor)
                         .size(height = 100., width = 100.)
                         .centerHorizontal()

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Components.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Components.fs
@@ -79,7 +79,7 @@ module Components =
                     .fillHorizontal(expand = true)
                     .margin (0., 5., 0., 5.)
 
-                Image("star.png", Aspect.AspectFit)
+                Image(Aspect.AspectFit, "star.png")
                     .isVisible(isFavorite)
                     .centerVertical()
                     .margin(0., 0., 15., 0.)
@@ -126,7 +126,7 @@ module Components =
 
         | Some picture ->
             ContentView(
-                Image(new MemoryStream(picture), Aspect.AspectFill)
+                Image(Aspect.AspectFill, new MemoryStream(picture))
             )
                 .gridRowSpan(
                 2

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/DetailPage.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/DetailPage.fs
@@ -111,7 +111,7 @@ module DetailPage =
             (Grid() {
                 getImageValueOrDefault "addphoto.png" Aspect.AspectFit contact.Picture
 
-                Image("star.png", Aspect.AspectFit)
+                Image(Aspect.AspectFit, "star.png")
                     .isVisible(contact.IsFavorite)
                     .size(height = 35., width = 35.)
                     .alignStartHorizontal()

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Helpers.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Helpers.fs
@@ -96,8 +96,8 @@ module Helpers =
 
     let getImageValueOrDefault (defaultValue: string) aspect (value: byte [] option) =
         match value with
-        | None -> Image(defaultValue, aspect)
-        | Some bytes -> Image(new MemoryStream(bytes), aspect)
+        | None -> Image(aspect, defaultValue)
+        | Some bytes -> Image(aspect, new MemoryStream(bytes))
 
 module Cmd =
     let performAsync asyncUnit =

--- a/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/CityView.fs
+++ b/samples/Xamarin.Forms/FabulousWeather/FabulousWeather/CityView.fs
@@ -4,6 +4,7 @@ open Fabulous
 open Fabulous.XamarinForms
 open System
 open WeatherApi
+open Xamarin.Forms
 
 open type Fabulous.XamarinForms.View
 
@@ -22,7 +23,7 @@ module CityView =
     let loadingView (cityName: string) =
         VStack() {
             Label(cityName.ToUpper())
-                .font(namedSize = Xamarin.Forms.NamedSize.Title)
+                .font(namedSize = NamedSize.Title)
                 .centerTextHorizontal()
                 .padding (0., 20., 0., 0.)
 
@@ -43,18 +44,18 @@ module CityView =
                         .font(Styles.CityNameFontSize)
                         .centerTextHorizontal ()
 
-                    Image($"{sanitizedCityName}.png", Xamarin.Forms.Aspect.AspectFit)
+                    Image(Aspect.AspectFit, $"{sanitizedCityName}.png")
                         .opacity (0.8)
 
                     Label($"{Helpers.kelvinToRoundedFahrenheit data.Temperature}°")
                         .font(Styles.CurrentTemperatureFontSize)
                         .centerTextHorizontal()
-                        .margin (Xamarin.Forms.Thickness(30., 0., 0., 0.))
+                        .margin (Thickness(30., 0., 0., 0.))
 
                     Label(data.WeatherKind.ToString().ToUpper())
                         .font(Styles.CurrentWeatherKindFontSize)
                         .centerTextHorizontal()
-                        .margin (Xamarin.Forms.Thickness(0., 10., 0., 0.))
+                        .margin (Thickness(0., 10., 0., 0.))
 
                     Label(
                         data
@@ -75,8 +76,8 @@ module CityView =
                                         .centerTextHorizontal ()
 
                                     Image(
-                                        Uri($"http://openweathermap.org/img/wn/{forecast.IconName}@2x.png"),
-                                        Xamarin.Forms.Aspect.AspectFit
+                                        Xamarin.Forms.Aspect.AspectFit,
+                                        Uri($"http://openweathermap.org/img/wn/{forecast.IconName}@2x.png")
                                     )
                                         .centerHorizontal()
                                         .centerVertical (expand = true)
@@ -95,10 +96,10 @@ module CityView =
 
     let cityView (index: int) (city: CityData) onRefreshing =
         let padding =
-            if Xamarin.Forms.Device.RuntimePlatform = Xamarin.Forms.Device.Android then
-                Xamarin.Forms.Thickness(0., 24., 0., 30.)
+            if Device.RuntimePlatform = Device.Android then
+                Thickness(0., 24., 0., 30.)
             else
-                Xamarin.Forms.Thickness(0., 0., 0., 40.)
+                Thickness(0., 0., 0., 40.)
 
         match city.Data with
         | Some data ->

--- a/samples/Xamarin.Forms/TicTacToe/TicTacToe/App.fs
+++ b/samples/Xamarin.Forms/TicTacToe/TicTacToe/App.fs
@@ -227,7 +227,7 @@ module App =
                                             .gridRow(row * 2)
                                             .gridColumn (col * 2)
                                     else
-                                        Image(imageForPos model.Board.[pos], Aspect.AspectFit)
+                                        Image(Aspect.AspectFit, imageForPos model.Board.[pos])
                                             .center()
                                             .margin(10.)
                                             .gridRow(row * 2)
@@ -249,7 +249,7 @@ module App =
                             Button("Restart game", Restart)
                                 .textColor(Color.Black)
                                 .backgroundColor(Color.LightBlue)
-                                .font(NamedSize.Large)
+                                .font(namedSize = NamedSize.Large)
                                 .gridRow (2)
                         }
                     )

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -7,7 +7,7 @@ open Xamarin.Forms
 type AppThemeValues<'T> =
     { Light: 'T
       Dark: 'T voption }
-    static member inline create<'T>(light : 'T, ?dark: 'T) =
+    static member inline create<'T>(light: 'T, ?dark: 'T) =
         { Light = light
           Dark =
               match dark with
@@ -72,4 +72,4 @@ module Attributes =
     let inline getAppTheme<'T> light dark =
         match dark with
         | Some dark -> AppThemeValues<'T>.create (light, dark)
-        | None -> AppThemeValues<'T>.create(light)
+        | None -> AppThemeValues<'T>.create (light)

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -4,10 +4,10 @@ open Fabulous
 open Xamarin.Forms
 
 [<Struct>]
-type AppThemeValues<'T> =
-    { Light: 'T
-      Dark: 'T voption }
-    static member inline create<'T>(light: 'T, ?dark: 'T) =
+type AppThemeValues<'T> = { Light: 'T; Dark: 'T voption }
+
+module AppTheme =
+    let inline create<'T> (light: 'T) (dark: 'T option) =
         { Light = light
           Dark =
               match dark with
@@ -68,8 +68,3 @@ module Attributes =
                 | ValueSome { Light = light; Dark = ValueNone } -> target.SetValue(bindableProperty, light)
                 | ValueSome { Light = light; Dark = ValueSome dark } ->
                     target.SetOnAppTheme(bindableProperty, light, dark))
-
-    let inline getAppTheme<'T> light dark =
-        match dark with
-        | Some dark -> AppThemeValues<'T>.create (light, dark)
-        | None -> AppThemeValues<'T>.create (light)

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -7,7 +7,7 @@ open Xamarin.Forms
 type AppThemeValues<'T> =
     { Light: 'T
       Dark: 'T voption }
-    static member inline create(light, dark) =
+    static member inline create<'T>(light : 'T, ?dark: 'T) =
         { Light = light
           Dark =
               match dark with
@@ -68,3 +68,8 @@ module Attributes =
                 | ValueSome { Light = light; Dark = ValueNone } -> target.SetValue(bindableProperty, light)
                 | ValueSome { Light = light; Dark = ValueSome dark } ->
                     target.SetOnAppTheme(bindableProperty, light, dark))
+
+    let inline getAppTheme<'T> light dark =
+        match dark with
+        | Some dark -> AppThemeValues<'T>.create (light, dark)
+        | None -> AppThemeValues<'T>.create(light)

--- a/src/Fabulous.XamarinForms/Views/Controls/Button.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Button.fs
@@ -75,8 +75,7 @@ module ButtonBuilders =
 type ButtonModifiers =
     [<Extension>]
     static member inline textColor(this: WidgetBuilder<'msg, #IButton>, light: Color, ?dark: Color) =
-        let appTheme = Attributes.getAppTheme<Color> light dark
-        this.AddScalar(Button.TextColor.WithValue(appTheme))
+        this.AddScalar(Button.TextColor.WithValue(AppTheme.create light dark))
 
     [<Extension>]
     static member inline textTransform(this: WidgetBuilder<'msg, #IButton>, value: TextTransform) =
@@ -88,8 +87,7 @@ type ButtonModifiers =
 
     [<Extension>]
     static member inline borderColor(this: WidgetBuilder<'msg, #IButton>, light: Color, ?dark: Color) =
-        let appTheme = Attributes.getAppTheme<Color> light dark
-        this.AddScalar(Button.BorderColor.WithValue(appTheme))
+        this.AddScalar(Button.BorderColor.WithValue(AppTheme.create light dark))
 
     [<Extension>]
     static member inline borderWidth(this: WidgetBuilder<'msg, #IButton>, value: float) =
@@ -159,33 +157,40 @@ type ButtonModifiers =
 
     [<Extension>]
     static member inline image(this: WidgetBuilder<'msg, #IButton>, light: ImageSource, ?dark: ImageSource) =
-        let appTheme =
-            Attributes.getAppTheme<ImageSource> light dark
-
-        this.AddScalar(Button.ImageSource.WithValue(appTheme))
+        this.AddScalar(Button.ImageSource.WithValue(AppTheme.create light dark))
 
     [<Extension>]
     static member inline image(this: WidgetBuilder<'msg, #IButton>, light: string, ?dark: string) =
-        match dark with
-        | Some dark -> ButtonModifiers.image (this, ImageSource.FromFile(light), ImageSource.FromFile(dark))
-        | None -> ButtonModifiers.image (this, ImageSource.FromFile(light))
+        let light = ImageSource.FromFile(light)
+
+        let dark =
+            match dark with
+            | None -> None
+            | Some v -> Some(ImageSource.FromFile(v))
+
+        ButtonModifiers.image (this, light, ?dark = dark)
 
     [<Extension>]
     static member inline image(this: WidgetBuilder<'msg, #IButton>, light: Uri, ?dark: Uri) =
-        match dark with
-        | Some dark -> ButtonModifiers.image (this, ImageSource.FromUri(light), ImageSource.FromUri(dark))
-        | None -> ButtonModifiers.image (this, ImageSource.FromUri(light))
+        let light = ImageSource.FromUri(light)
+
+        let dark =
+            match dark with
+            | None -> None
+            | Some v -> Some(ImageSource.FromUri(v))
+
+        ButtonModifiers.image (this, light, ?dark = dark)
 
     [<Extension>]
     static member inline image(this: WidgetBuilder<'msg, #IButton>, light: Stream, ?dark: Stream) =
-        match dark with
-        | Some dark ->
-            ButtonModifiers.image (
-                this,
-                ImageSource.FromStream(fun () -> light),
-                ImageSource.FromStream(fun () -> dark)
-            )
-        | None -> ButtonModifiers.image (this, ImageSource.FromStream(fun () -> light))
+        let light = ImageSource.FromStream(fun () -> light)
+
+        let dark =
+            match dark with
+            | None -> None
+            | Some v -> Some(ImageSource.FromStream(fun () -> v))
+
+        ButtonModifiers.image (this, light, ?dark = dark)
 
     [<Extension>]
     static member inline onPressed(this: WidgetBuilder<'msg, #IButton>, msg: 'msg) =

--- a/src/Fabulous.XamarinForms/Views/Controls/Button.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Button.fs
@@ -36,7 +36,7 @@ module Button =
         Attributes.defineBindable<float> Button.FontSizeProperty
 
     let ImageSource =
-        Attributes.defineAppThemeBindable<string> Button.ImageSourceProperty
+        Attributes.defineAppThemeBindable<ImageSource> Button.ImageSourceProperty
 
     let Padding =
         Attributes.defineBindable<Thickness> Button.PaddingProperty
@@ -154,8 +154,8 @@ type ButtonModifiers =
         res
 
     [<Extension>]
-    static member inline imageSource(this: WidgetBuilder<'msg, #IButton>, light: string, ?dark: string) =
-        this.AddScalar(Button.ImageSource.WithValue(AppThemeValues<string>.create (light, dark)))
+    static member inline imageSource(this: WidgetBuilder<'msg, #IButton>, light: ImageSource, ?dark: ImageSource) =
+        this.AddScalar(Button.ImageSource.WithValue(AppThemeValues.create<ImageSource> (light, dark)))
 
     [<Extension>]
     static member inline onPressed(this: WidgetBuilder<'msg, #IButton>, msg: 'msg) =

--- a/src/Fabulous.XamarinForms/Views/Controls/Button.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Button.fs
@@ -1,5 +1,7 @@
 namespace Fabulous.XamarinForms
 
+open System
+open System.IO
 open System.Runtime.CompilerServices
 open Fabulous
 open Fabulous.XamarinForms
@@ -73,7 +75,8 @@ module ButtonBuilders =
 type ButtonModifiers =
     [<Extension>]
     static member inline textColor(this: WidgetBuilder<'msg, #IButton>, light: Color, ?dark: Color) =
-        this.AddScalar(Button.TextColor.WithValue(AppThemeValues<Color>.create (light, dark)))
+        let appTheme = Attributes.getAppTheme<Color> light dark
+        this.AddScalar(Button.TextColor.WithValue(appTheme))
 
     [<Extension>]
     static member inline textTransform(this: WidgetBuilder<'msg, #IButton>, value: TextTransform) =
@@ -85,7 +88,8 @@ type ButtonModifiers =
 
     [<Extension>]
     static member inline borderColor(this: WidgetBuilder<'msg, #IButton>, light: Color, ?dark: Color) =
-        this.AddScalar(Button.BorderColor.WithValue(AppThemeValues<Color>.create (light, dark)))
+        let appTheme = Attributes.getAppTheme<Color> light dark
+        this.AddScalar(Button.BorderColor.WithValue(appTheme))
 
     [<Extension>]
     static member inline borderWidth(this: WidgetBuilder<'msg, #IButton>, value: float) =
@@ -154,8 +158,34 @@ type ButtonModifiers =
         res
 
     [<Extension>]
-    static member inline imageSource(this: WidgetBuilder<'msg, #IButton>, light: ImageSource, ?dark: ImageSource) =
-        this.AddScalar(Button.ImageSource.WithValue(AppThemeValues.create<ImageSource> (light, dark)))
+    static member inline image(this: WidgetBuilder<'msg, #IButton>, light: ImageSource, ?dark: ImageSource) =
+        let appTheme =
+            Attributes.getAppTheme<ImageSource> light dark
+
+        this.AddScalar(Button.ImageSource.WithValue(appTheme))
+
+    [<Extension>]
+    static member inline image(this: WidgetBuilder<'msg, #IButton>, light: string, ?dark: string) =
+        match dark with
+        | Some dark -> ButtonModifiers.image (this, ImageSource.FromFile(light), ImageSource.FromFile(dark))
+        | None -> ButtonModifiers.image (this, ImageSource.FromFile(light))
+
+    [<Extension>]
+    static member inline image(this: WidgetBuilder<'msg, #IButton>, light: Uri, ?dark: Uri) =
+        match dark with
+        | Some dark -> ButtonModifiers.image (this, ImageSource.FromUri(light), ImageSource.FromUri(dark))
+        | None -> ButtonModifiers.image (this, ImageSource.FromUri(light))
+
+    [<Extension>]
+    static member inline image(this: WidgetBuilder<'msg, #IButton>, light: Stream, ?dark: Stream) =
+        match dark with
+        | Some dark ->
+            ButtonModifiers.image (
+                this,
+                ImageSource.FromStream(fun () -> light),
+                ImageSource.FromStream(fun () -> dark)
+            )
+        | None -> ButtonModifiers.image (this, ImageSource.FromStream(fun () -> light))
 
     [<Extension>]
     static member inline onPressed(this: WidgetBuilder<'msg, #IButton>, msg: 'msg) =

--- a/src/Fabulous.XamarinForms/Views/Controls/Image.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Image.fs
@@ -21,23 +21,17 @@ module Image =
         Attributes.defineBindable<bool> Image.IsOpaqueProperty
 
     let Source =
-        Attributes.defineAppThemeBindable<string> Image.SourceProperty
+        Attributes.defineAppThemeBindable<ImageSource> Image.SourceProperty
 
 [<AutoOpen>]
 module ImageBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline Image<'msg>(imageSource: ImageSource, aspect: Aspect) =
-            WidgetBuilder<'msg, IImage>(
-                Image.WidgetKey,
-                (Attributes.defineBindable<ImageSource> Image.SourceProperty)
-                    .WithValue(imageSource),
-                Image.Aspect.WithValue(aspect)
-            )
 
-        static member inline Image<'msg>(light: string, ?dark: string) =
+        static member inline Image<'msg>(light: ImageSource, aspect: Aspect, ?dark: ImageSource) =
             WidgetBuilder<'msg, IImage>(
                 Image.WidgetKey,
-                Image.Source.WithValue(AppThemeValues<string>.create (light, dark))
+                Image.Aspect.WithValue(aspect),
+                Image.Source.WithValue(AppThemeValues.create<ImageSource> (light, dark))
             )
 
         static member inline Image<'msg>(path: string, aspect: Aspect) =
@@ -51,10 +45,6 @@ module ImageBuilders =
 
 [<Extension>]
 type ImageModifiers =
-    [<Extension>]
-    static member inline aspect(this: WidgetBuilder<'msg, #IImage>, aspect: Aspect) =
-        this.AddScalar(Image.Aspect.WithValue(aspect))
-
     [<Extension>]
     static member inline isAnimationPlaying(this: WidgetBuilder<'msg, #IImage>, isAnimationPlaying: bool) =
         this.AddScalar(Image.IsAnimationPlaying.WithValue(isAnimationPlaying))

--- a/src/Fabulous.XamarinForms/Views/Controls/Image.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Image.fs
@@ -1,6 +1,8 @@
 namespace Fabulous.XamarinForms
 
+open System.Runtime.CompilerServices
 open Fabulous
+open Fabulous.XamarinForms
 open Xamarin.Forms
 
 type IImage =
@@ -9,11 +11,17 @@ type IImage =
 module Image =
     let WidgetKey = Widgets.register<Image> ()
 
-    let Source =
-        Attributes.defineBindable<ImageSource> Image.SourceProperty
-
     let Aspect =
         Attributes.defineBindable<Aspect> Image.AspectProperty
+
+    let IsAnimationPlaying =
+        Attributes.defineBindable<bool> Image.IsAnimationPlayingProperty
+
+    let IsOpaque =
+        Attributes.defineBindable<bool> Image.IsOpaqueProperty
+
+    let Source =
+        Attributes.defineAppThemeBindable<string> Image.SourceProperty
 
 [<AutoOpen>]
 module ImageBuilders =
@@ -21,8 +29,15 @@ module ImageBuilders =
         static member inline Image<'msg>(imageSource: ImageSource, aspect: Aspect) =
             WidgetBuilder<'msg, IImage>(
                 Image.WidgetKey,
-                Image.Source.WithValue(imageSource),
+                (Attributes.defineBindable<ImageSource> Image.SourceProperty)
+                    .WithValue(imageSource),
                 Image.Aspect.WithValue(aspect)
+            )
+
+        static member inline Image<'msg>(light: string, ?dark: string) =
+            WidgetBuilder<'msg, IImage>(
+                Image.WidgetKey,
+                Image.Source.WithValue(AppThemeValues<string>.create (light, dark))
             )
 
         static member inline Image<'msg>(path: string, aspect: Aspect) =
@@ -33,3 +48,17 @@ module ImageBuilders =
 
         static member inline Image<'msg>(stream: System.IO.Stream, aspect: Aspect) =
             View.Image<'msg>(ImageSource.FromStream(fun () -> stream), aspect)
+
+[<Extension>]
+type ImageModifiers =
+    [<Extension>]
+    static member inline aspect(this: WidgetBuilder<'msg, #IImage>, aspect: Aspect) =
+        this.AddScalar(Image.Aspect.WithValue(aspect))
+
+    [<Extension>]
+    static member inline isAnimationPlaying(this: WidgetBuilder<'msg, #IImage>, isAnimationPlaying: bool) =
+        this.AddScalar(Image.IsAnimationPlaying.WithValue(isAnimationPlaying))
+
+    [<Extension>]
+    static member inline isOpaque(this: WidgetBuilder<'msg, #IImage>, isOpaque: bool) =
+        this.AddScalar(Image.IsOpaque.WithValue(isOpaque))

--- a/src/Fabulous.XamarinForms/Views/Controls/Image.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Image.fs
@@ -28,37 +28,42 @@ module Image =
 [<AutoOpen>]
 module ImageBuilders =
     type Fabulous.XamarinForms.View with
-
         static member inline Image<'msg>(aspect: Aspect, light: ImageSource, ?dark: ImageSource) =
-            let appTheme =
-                Attributes.getAppTheme<ImageSource> light dark
-
             WidgetBuilder<'msg, IImage>(
                 Image.WidgetKey,
                 Image.Aspect.WithValue(aspect),
-                Image.Source.WithValue(appTheme)
+                Image.Source.WithValue(AppTheme.create light dark)
             )
 
         static member inline Image<'msg>(aspect: Aspect, light: string, ?dark: string) =
-            match dark with
-            | Some dark -> View.Image<'msg>(aspect, ImageSource.FromFile(light), ImageSource.FromFile(dark))
-            | None -> View.Image<'msg>(aspect, ImageSource.FromFile(light))
+            let light = ImageSource.FromFile(light)
+
+            let dark =
+                match dark with
+                | None -> None
+                | Some v -> Some(ImageSource.FromFile(v))
+
+            View.Image<'msg>(aspect, light, ?dark = dark)
 
         static member inline Image<'msg>(aspect: Aspect, light: Uri, ?dark: Uri) =
-            match dark with
-            | Some dark -> View.Image<'msg>(aspect, ImageSource.FromUri(light), ImageSource.FromUri(dark))
-            | None -> View.Image<'msg>(aspect, ImageSource.FromUri(light))
+            let light = ImageSource.FromUri(light)
 
+            let dark =
+                match dark with
+                | None -> None
+                | Some v -> Some(ImageSource.FromUri(v))
+
+            View.Image<'msg>(aspect, light, ?dark = dark)
 
         static member inline Image<'msg>(aspect: Aspect, light: Stream, ?dark: Stream) =
-            match dark with
-            | Some dark ->
-                View.Image<'msg>(
-                    aspect,
-                    ImageSource.FromStream(fun () -> light),
-                    ImageSource.FromStream(fun () -> dark)
-                )
-            | None -> View.Image<'msg>(aspect, ImageSource.FromStream(fun () -> light))
+            let light = ImageSource.FromStream(fun () -> light)
+
+            let dark =
+                match dark with
+                | None -> None
+                | Some v -> Some(ImageSource.FromStream(fun () -> v))
+
+            View.Image<'msg>(aspect, light, ?dark = dark)
 
 [<Extension>]
 type ImageModifiers =

--- a/src/Fabulous.XamarinForms/Views/Controls/Image.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Image.fs
@@ -1,9 +1,11 @@
 namespace Fabulous.XamarinForms
 
+open System
 open System.Runtime.CompilerServices
 open Fabulous
 open Fabulous.XamarinForms
 open Xamarin.Forms
+open System.IO
 
 type IImage =
     inherit IView
@@ -27,21 +29,36 @@ module Image =
 module ImageBuilders =
     type Fabulous.XamarinForms.View with
 
-        static member inline Image<'msg>(light: ImageSource, aspect: Aspect, ?dark: ImageSource) =
+        static member inline Image<'msg>(aspect: Aspect, light: ImageSource, ?dark: ImageSource) =
+            let appTheme =
+                Attributes.getAppTheme<ImageSource> light dark
+
             WidgetBuilder<'msg, IImage>(
                 Image.WidgetKey,
                 Image.Aspect.WithValue(aspect),
-                Image.Source.WithValue(AppThemeValues.create<ImageSource> (light, dark))
+                Image.Source.WithValue(appTheme)
             )
 
-        static member inline Image<'msg>(path: string, aspect: Aspect) =
-            View.Image<'msg>(ImageSource.FromFile(path), aspect)
+        static member inline Image<'msg>(aspect: Aspect, light: string, ?dark: string) =
+            match dark with
+            | Some dark -> View.Image<'msg>(aspect, ImageSource.FromFile(light), ImageSource.FromFile(dark))
+            | None -> View.Image<'msg>(aspect, ImageSource.FromFile(light))
 
-        static member inline Image<'msg>(uri: System.Uri, aspect: Aspect) =
-            View.Image<'msg>(ImageSource.FromUri(uri), aspect)
+        static member inline Image<'msg>(aspect: Aspect, light: Uri, ?dark: Uri) =
+            match dark with
+            | Some dark -> View.Image<'msg>(aspect, ImageSource.FromUri(light), ImageSource.FromUri(dark))
+            | None -> View.Image<'msg>(aspect, ImageSource.FromUri(light))
 
-        static member inline Image<'msg>(stream: System.IO.Stream, aspect: Aspect) =
-            View.Image<'msg>(ImageSource.FromStream(fun () -> stream), aspect)
+
+        static member inline Image<'msg>(aspect: Aspect, light: Stream, ?dark: Stream) =
+            match dark with
+            | Some dark ->
+                View.Image<'msg>(
+                    aspect,
+                    ImageSource.FromStream(fun () -> light),
+                    ImageSource.FromStream(fun () -> dark)
+                )
+            | None -> View.Image<'msg>(aspect, ImageSource.FromStream(fun () -> light))
 
 [<Extension>]
 type ImageModifiers =

--- a/src/Fabulous.XamarinForms/Views/_VisualElement.fs
+++ b/src/Fabulous.XamarinForms/Views/_VisualElement.fs
@@ -39,7 +39,8 @@ type VisualElementModifiers =
 
     [<Extension>]
     static member inline backgroundColor(this: WidgetBuilder<'msg, #IVisualElement>, light: Color, ?dark: Color) =
-        this.AddScalar(VisualElement.BackgroundColor.WithValue(AppThemeValues<Color>.create (light, dark)))
+        let appTheme = Attributes.getAppTheme<Color> light dark
+        this.AddScalar(VisualElement.BackgroundColor.WithValue(appTheme))
 
     [<Extension>]
     static member inline isVisible(this: WidgetBuilder<'msg, #IVisualElement>, value: bool) =

--- a/src/Fabulous.XamarinForms/Views/_VisualElement.fs
+++ b/src/Fabulous.XamarinForms/Views/_VisualElement.fs
@@ -39,8 +39,7 @@ type VisualElementModifiers =
 
     [<Extension>]
     static member inline backgroundColor(this: WidgetBuilder<'msg, #IVisualElement>, light: Color, ?dark: Color) =
-        let appTheme = Attributes.getAppTheme<Color> light dark
-        this.AddScalar(VisualElement.BackgroundColor.WithValue(appTheme))
+        this.AddScalar(VisualElement.BackgroundColor.WithValue(AppTheme.create light dark))
 
     [<Extension>]
     static member inline isVisible(this: WidgetBuilder<'msg, #IVisualElement>, value: bool) =


### PR DESCRIPTION
This PR add Image extensions based on https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.image?view=xamarin-forms :

- ImageSource support
- AppThemeBindable support
- ImageSource.FromFile support
- ImageSource.FromUri support
- ImageSource.FromStream support