### PR TITLE
Add .NET Standard 2.1 target to allow old XF projects

### DIFF
--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-ios;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>net6.0-ios;net6.0-android;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
     <VersionPrefix>2.0.0</VersionPrefix>
@@ -81,7 +81,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="6.0.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-android' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0-ios' ">
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-ios' ">

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReadmeFile>PackageREADME.md</PackageReadmeFile>
         <VersionPrefix>2.0.0</VersionPrefix>


### PR DESCRIPTION
Add support for .NET Standard 2.0 to Fabulous and Fabulous.XamarinForms in addition to `net6.0`, `net6.0-ios` and `net6.0-android`.
This will enable old style Xamarin.Forms projects to use Fabulous v2