### PR TITLE
ScrollView + Extensions

### DIFF
--- a/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
@@ -1,5 +1,6 @@
 namespace Fabulous.XamarinForms
 
+open System.Runtime.CompilerServices
 open Fabulous
 open Xamarin.Forms
 
@@ -9,11 +10,29 @@ type IScrollView =
 module ScrollView =
     let WidgetKey = Widgets.register<ScrollView> ()
 
+    let Orientation =
+        Attributes.defineBindable<ScrollOrientation> ScrollView.OrientationProperty
+
+    let ScrollX =
+        Attributes.defineBindable<float> ScrollView.ScrollXProperty
+
+    let ScrollY =
+        Attributes.defineBindable<float> ScrollView.ScrollYProperty
+
+    let HorizontalScrollBarVisibility =
+        Attributes.defineBindable<ScrollBarVisibility> ScrollView.HorizontalScrollBarVisibilityProperty
+
+    let VerticalScrollBarVisibility =
+        Attributes.defineBindable<ScrollBarVisibility> ScrollView.VerticalScrollBarVisibilityProperty
+
     let Content =
         Attributes.defineWidget
             "ScrollView_Content"
             (fun target -> ViewNode.get (target :?> ScrollView).Content)
             (fun target value -> (target :?> ScrollView).Content <- value)
+
+    let Scrolled =
+        Attributes.defineEvent<ScrolledEventArgs> "ScrollView_Scrolled" (fun target -> (target :?> ScrollView).Scrolled)
 
 [<AutoOpen>]
 module ScrollViewBuilders =
@@ -22,3 +41,50 @@ module ScrollViewBuilders =
             WidgetHelpers.buildWidgets<'msg, IScrollView>
                 ScrollView.WidgetKey
                 [| ScrollView.Content.WithValue(content.Compile()) |]
+
+[<Extension>]
+type ScrollViewModifiers =
+
+    /// <summary>Sets the scrolling direction of the ScrollView</summary>
+    /// <param name="orientation">of type ScrollOrientation. The default value of this property is Vertical</param>
+    [<Extension>]
+    static member inline orientation(this: WidgetBuilder<'msg, #IScrollView>, value: ScrollOrientation) =
+        this.AddScalar(ScrollView.Orientation.WithValue(value))
+
+    /// <summary>Sets when the horizontal scroll bar is visible.</summary>
+    /// <param name="value">of type ScrollBarVisibility.</param>
+    [<Extension>]
+    static member inline horizontalScrollBarVisibility
+        (
+            this: WidgetBuilder<'msg, #IScrollView>,
+            value: ScrollBarVisibility
+        ) =
+        this.AddScalar(ScrollView.HorizontalScrollBarVisibility.WithValue(value))
+
+    /// <summary>Sets when the vertical scroll bar is visible.</summary>
+    /// <param name="value">of type ScrollBarVisibility.</param>
+    [<Extension>]
+    static member inline verticalScrollBarVisibility
+        (
+            this: WidgetBuilder<'msg, #IScrollView>,
+            value: ScrollBarVisibility
+        ) =
+        this.AddScalar(ScrollView.VerticalScrollBarVisibility.WithValue(value))
+
+    /// <summary>Sets the current X scroll position.</summary>
+    /// <param name="value">of type float, The default value of this read-only property is 0.</param>
+    [<Extension>]
+    static member inline scrollX(this: WidgetBuilder<'msg, #IScrollView>, value: float) =
+        this.AddScalar(ScrollView.ScrollX.WithValue(value))
+
+    /// <summary>Sets the current Y scroll position.</summary>
+    /// <param name="value">of type float, The default value of this read-only property is 0.</param>
+    [<Extension>]
+    static member inline scrollY(this: WidgetBuilder<'msg, #IScrollView>, value: float) =
+        this.AddScalar(ScrollView.ScrollY.WithValue(value))
+
+    /// <summary>Event that is fired when the scrollView is scrolled.</summary>
+    /// <param name="onScrolled">Msg to dispatch when the scrollView is scrolled.</param>
+    [<Extension>]
+    static member inline onScrolled(this: WidgetBuilder<'msg, #IScrollView>, onScrolled: ScrolledEventArgs -> 'msg) =
+        this.AddScalar(ScrollView.Scrolled.WithValue(fun args -> onScrolled args |> box))


### PR DESCRIPTION
This PR adds ScrollView extension based on https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/layouts/scrollview

## Open questions :

Using V1 : 
 - When using ScrollView in order to get access to the ScrollView ScrollToAsync . We had to rely on WiewRef  to get acess to the   underlined control. 
- You can use the ScrollX and ScrollY to change the position , But this will be not animated


V2 : 
I think we cn get acess to those animated scrolling methods  like  this

```csharp
public System.Threading.Tasks.Task ScrollToAsync (double x, double y, bool animated);

```
```fsharp
let ScrollToAsync =
    Attributes.define<struct (float * float * bool)>
        "ScrollView_ScrollToAsync"
        (fun newValueOpt node ->
            let scrollView = node.Target :?> ScrollView
            match newValueOpt with
            | ValueNone ->
                scrollView.ScrollToAsync(0, 0, false)
                |> Async.AwaitTask
                |> Async.Start
            | ValueSome (x, y, animated) ->
                scrollView.ScrollToAsync(x, y, animated)
                |> Async.AwaitTask
                |> Async.Start)
```

There is a second overload for the ScrollToAsync that receives an Xamarin.Forms.Element

```csharp
public System.Threading.Tasks.Task ScrollToAsync (Xamarin.Forms.Element element, Xamarin.Forms.ScrollToPosition position, bool animated);
```
For this one we could use the same approach as the ViewRef approach done in #81 
