### PR TITLE
Add ViewRef to support IndicatorView <-> CarouselView binding

### DIFF
--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -58,25 +58,6 @@ type FabulousTimePicker() =
 type FabulousListView() =
     inherit ListView(ListViewCachingStrategy.RecycleElement)
 
-type FabulousIndicatorView() =
-    inherit IndicatorView()
-
-    let mutable oldPositionValue: int = 0
-
-    let positionChanged =
-        Event<EventHandler<PositionChangedEventArgs>, _>()
-
-    [<CLIEvent>]
-    member _.PositionChanged = positionChanged.Publish
-
-    override this.OnPropertyChanged(propertyName) =
-        if propertyName = IndicatorView.PositionProperty.PropertyName then
-            positionChanged.Trigger(this, PositionChangedEventArgs(oldPositionValue, this.Position))
-
-    override this.OnPropertyChanging(propertyName) =
-        if propertyName = IndicatorView.PositionProperty.PropertyName then
-            oldPositionValue <- this.Position
-
 /// Xamarin.Forms doesn't provide an event for textChanged the EntryCell, so we implement it
 type CustomEntryCell() =
     inherit EntryCell()

--- a/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
@@ -9,8 +9,7 @@ type IIndicatorView =
     inherit ITemplatedView
 
 module IndicatorView =
-    let WidgetKey =
-        Widgets.register<FabulousIndicatorView> ()
+    let WidgetKey = Widgets.register<IndicatorView> ()
 
     let ItemsSource<'T> =
         Attributes.defineBindableWithComparer<WidgetItems<'T>, WidgetItems<'T>, System.Collections.Generic.IEnumerable<Widget>>
@@ -22,9 +21,6 @@ module IndicatorView =
                         modelValue.Template x
                 })
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
-
-    let Count =
-        Attributes.defineBindable<int> IndicatorView.CountProperty
 
     let HideSingle =
         Attributes.defineBindable<bool> IndicatorView.HideSingleProperty
@@ -41,26 +37,16 @@ module IndicatorView =
     let MaximumVisible =
         Attributes.defineBindable<int> IndicatorView.MaximumVisibleProperty
 
-    let Position =
-        Attributes.defineBindable<int> IndicatorView.PositionProperty
-
     let SelectedIndicatorColor =
         Attributes.defineAppThemeBindable<Color> IndicatorView.SelectedIndicatorColorProperty
-
-    let PositionChanged =
-        Attributes.defineEvent<Fabulous.XamarinForms.PositionChangedEventArgs>
-            "FabulousIndicatorView_PositionChanged"
-            (fun target -> (target :?> FabulousIndicatorView).PositionChanged)
 
 [<AutoOpen>]
 module IndicatorViewBuilders =
     type Fabulous.XamarinForms.View with
-        static member inline IndicatorView<'msg>(count: int, position: int, positionChanged: int -> 'msg) =
+        static member inline IndicatorView<'msg>(reference: ViewRef<IndicatorView>) =
             WidgetBuilder<'msg, IIndicatorView>(
                 IndicatorView.WidgetKey,
-                IndicatorView.Count.WithValue(count),
-                IndicatorView.Position.WithValue(position),
-                IndicatorView.PositionChanged.WithValue(fun args -> positionChanged args.CurrentPosition |> box)
+                ViewRefAttributes.ViewRef.WithValue(reference.Unbox)
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
@@ -1,6 +1,6 @@
 namespace Fabulous.XamarinForms
 
-open System.Runtime.CompilerServices
+open System.Collections.Generic
 open Xamarin.Forms.Shapes
 open Fabulous
 open Fabulous.XamarinForms
@@ -13,7 +13,7 @@ module GeometryGroup =
     let WidgetKey = Widgets.register<GeometryGroup> ()
 
     let Children =
-        Attributes.defineWidgetCollection "GeometryGroup_Children" (fun target -> (target :?> GeometryGroup).Children)
+        Attributes.defineWidgetCollection "GeometryGroup_Children" (fun target -> (target :?> GeometryGroup).Children :> IList<_>)
 
     let FillRule =
         Attributes.defineBindable<FillRule> GeometryGroup.FillRuleProperty

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
@@ -13,7 +13,9 @@ module GeometryGroup =
     let WidgetKey = Widgets.register<GeometryGroup> ()
 
     let Children =
-        Attributes.defineWidgetCollection "GeometryGroup_Children" (fun target -> (target :?> GeometryGroup).Children :> IList<_>)
+        Attributes.defineWidgetCollection
+            "GeometryGroup_Children"
+            (fun target -> (target :?> GeometryGroup).Children :> IList<_>)
 
     let FillRule =
         Attributes.defineBindable<FillRule> GeometryGroup.FillRuleProperty

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/PathGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/PathGeometry.fs
@@ -1,5 +1,6 @@
 namespace Fabulous.XamarinForms
 
+open System.Collections.Generic
 open Fabulous
 open Fabulous.XamarinForms
 open Xamarin.Forms
@@ -14,7 +15,7 @@ module PathGeometry =
     let FiguresWidgets =
         Attributes.defineWidgetCollection
             "PathGeometry_FiguresWidgets"
-            (fun target -> (target :?> PathGeometry).Figures)
+            (fun target -> (target :?> PathGeometry).Figures :> IList<_>)
 
     let FiguresString =
         Attributes.define<string>

--- a/src/Fabulous.XamarinForms/Views/Shapes/Line.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Line.fs
@@ -22,10 +22,10 @@ module Line =
 
                 match newValueOpt with
                 | ValueNone ->
-                    line.X1 <- 0
-                    line.Y1 <- 0
-                    line.X2 <- 0
-                    line.Y2 <- 0
+                    line.X1 <- 0.
+                    line.Y1 <- 0.
+                    line.X2 <- 0.
+                    line.Y2 <- 0.
                 | ValueSome (startPoint, endPoint) ->
                     line.X1 <- startPoint.X
                     line.Y1 <- startPoint.Y

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/CompositeTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/CompositeTransform.fs
@@ -19,8 +19,8 @@ module CompositeTransform =
 
                 match newValueOpt with
                 | ValueNone ->
-                    line.CenterX <- 0
-                    line.CenterY <- 0
+                    line.CenterX <- 0.
+                    line.CenterY <- 0.
                 | ValueSome (x, y) ->
                     line.CenterX <- x
                     line.CenterY <- y)
@@ -33,8 +33,8 @@ module CompositeTransform =
 
                 match newValueOpt with
                 | ValueNone ->
-                    line.ScaleX <- 0
-                    line.ScaleY <- 0
+                    line.ScaleX <- 0.
+                    line.ScaleY <- 0.
                 | ValueSome (x, y) ->
                     line.ScaleX <- x
                     line.ScaleY <- y)
@@ -47,8 +47,8 @@ module CompositeTransform =
 
                 match newValueOpt with
                 | ValueNone ->
-                    line.SkewX <- 0
-                    line.SkewY <- 0
+                    line.SkewX <- 0.
+                    line.SkewY <- 0.
                 | ValueSome (x, y) ->
                     line.SkewX <- x
                     line.SkewY <- y)
@@ -61,8 +61,8 @@ module CompositeTransform =
 
                 match newValueOpt with
                 | ValueNone ->
-                    line.TranslateX <- 0
-                    line.TranslateY <- 0
+                    line.TranslateX <- 0.
+                    line.TranslateY <- 0.
                 | ValueSome (x, y) ->
                     line.TranslateX <- x
                     line.TranslateY <- y)

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/ScaleTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/ScaleTransform.fs
@@ -18,8 +18,8 @@ module ScaleTransform =
 
                 match newValueOpt with
                 | ValueNone ->
-                    line.ScaleX <- 0
-                    line.ScaleY <- 0
+                    line.ScaleX <- 0.
+                    line.ScaleY <- 0.
                 | ValueSome (x, y) ->
                     line.ScaleX <- x
                     line.ScaleY <- y)

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/SkewTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/SkewTransform.fs
@@ -18,8 +18,8 @@ module SkewTransform =
 
                 match newValueOpt with
                 | ValueNone ->
-                    line.AngleX <- 0
-                    line.AngleY <- 0
+                    line.AngleX <- 0.
+                    line.AngleY <- 0.
                 | ValueSome (x, y) ->
                     line.AngleX <- x
                     line.AngleY <- y)

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
@@ -13,7 +13,9 @@ module TransformGroup =
     let WidgetKey = Widgets.register<TransformGroup> ()
 
     let Children =
-        Attributes.defineWidgetCollection "TransformGroup_Children" (fun target -> (target :?> TransformGroup).Children :> IList<_>)
+        Attributes.defineWidgetCollection
+            "TransformGroup_Children"
+            (fun target -> (target :?> TransformGroup).Children :> IList<_>)
 
 [<AutoOpen>]
 module TransformGroupBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
@@ -1,5 +1,6 @@
 namespace Fabulous.XamarinForms
 
+open System.Collections.Generic
 open Fabulous
 open Fabulous.XamarinForms
 open Xamarin.Forms.Shapes
@@ -12,7 +13,7 @@ module TransformGroup =
     let WidgetKey = Widgets.register<TransformGroup> ()
 
     let Children =
-        Attributes.defineWidgetCollection "TransformGroup_Children" (fun target -> (target :?> TransformGroup).Children)
+        Attributes.defineWidgetCollection "TransformGroup_Children" (fun target -> (target :?> TransformGroup).Children :> IList<_>)
 
 [<AutoOpen>]
 module TransformGroupBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
@@ -13,7 +13,9 @@ module PathFigure =
     let WidgetKey = Widgets.register<PathFigure> ()
 
     let Segments =
-        Attributes.defineWidgetCollection "PathGeometry_Segments" (fun target -> (target :?> PathFigure).Segments :> IList<_>)
+        Attributes.defineWidgetCollection
+            "PathGeometry_Segments"
+            (fun target -> (target :?> PathFigure).Segments :> IList<_>)
 
     let StartPoint =
         Attributes.defineBindable<Point> PathFigure.StartPointProperty

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
@@ -1,5 +1,6 @@
 namespace Fabulous.XamarinForms
 
+open System.Collections.Generic
 open System.Runtime.CompilerServices
 open Fabulous
 open Xamarin.Forms
@@ -12,7 +13,7 @@ module PathFigure =
     let WidgetKey = Widgets.register<PathFigure> ()
 
     let Segments =
-        Attributes.defineWidgetCollection "PathGeometry_Segments" (fun target -> (target :?> PathFigure).Segments)
+        Attributes.defineWidgetCollection "PathGeometry_Segments" (fun target -> (target :?> PathFigure).Segments :> IList<_>)
 
     let StartPoint =
         Attributes.defineBindable<Point> PathFigure.StartPointProperty

--- a/src/Fabulous/Fabulous.fsproj
+++ b/src/Fabulous/Fabulous.fsproj
@@ -26,6 +26,7 @@
         <Compile Include="Memo.fs" />
         <Compile Include="MapMsg.fs" />
         <Compile Include="View.fs" />
+        <Compile Include="ViewRef.fs" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Update="FSharp.Core" Version="6.0.1" />

--- a/src/Fabulous/IViewNode.fs
+++ b/src/Fabulous/IViewNode.fs
@@ -1,5 +1,30 @@
 namespace Fabulous
 
+type ViewRef(onAttached, onDetached) =
+    let handle = System.WeakReference<obj>(null)
+
+    /// Check if the new target is the same than the previous one
+    /// This is done to avoid triggering change events when nothing changes
+    member private __.IsSameTarget(target) =
+        match handle.TryGetTarget() with
+        | true, res when res = target -> true
+        | _ -> false
+
+    member x.Set(target: obj) : unit =
+        if not (x.IsSameTarget(target)) then
+            handle.SetTarget(target)
+            onAttached x target
+
+    member x.Unset() : unit =
+        if not (x.IsSameTarget(null)) then
+            handle.SetTarget(null)
+            onDetached x ()
+
+    member _.TryValue =
+        match handle.TryGetTarget() with
+        | true, null -> None
+        | true, res -> Some res
+        | _ -> None
 
 /// Context of the whole view tree
 [<Struct>]
@@ -12,6 +37,7 @@ and IViewNode =
     abstract member Target: obj
     abstract member Parent: IViewNode voption
     abstract member TreeContext: ViewTreeContext
+    abstract member Reference: ViewRef voption with get, set
     abstract member MapMsg: (obj -> obj) voption with get, set
 
     // note that Widget is struct type, thus we have boxing via option

--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -79,6 +79,7 @@ type ViewNode(parentNode: IViewNode voption, treeContext: ViewTreeContext, targe
         member _.Target = targetRef.Target
         member _.TreeContext = treeContext
         member _.Parent = parentNode
+        member val Reference: ViewRef voption = ValueNone with get, set
         member val MapMsg: (obj -> obj) voption = ValueNone with get, set
         member val MemoizedWidget: Widget option = None with get, set
 

--- a/src/Fabulous/ViewRef.fs
+++ b/src/Fabulous/ViewRef.fs
@@ -1,0 +1,50 @@
+namespace Fabulous
+
+open System
+
+type ViewRef<'T when 'T: not struct>() =
+    let attached = Event<EventHandler<'T>, 'T>()
+    let detached = Event<EventHandler, EventArgs>()
+
+    let onAttached sender target = attached.Trigger(sender, unbox target)
+    let onDetached sender () = detached.Trigger(sender, EventArgs())
+
+    let handle = ViewRef(onAttached, onDetached)
+
+    [<CLIEvent>]
+    member _.Attached = attached.Publish
+
+    [<CLIEvent>]
+    member _.Detached = detached.Publish
+
+    member _.Value: 'T =
+        match handle.TryValue with
+        | Some res -> unbox res
+        | None -> failwith "view reference target has been collected or was not set"
+
+    member _.TryValue: 'T option =
+        match handle.TryValue with
+        | Some res -> Some(unbox res)
+        | None -> None
+
+    member _.Unbox = handle
+
+module ViewRefAttributes =
+    let ViewRef =
+        Attributes.defineScalarWithConverter<ViewRef, _, _>
+            "Fabulous_ViewRef"
+            id
+            id
+            ScalarAttributeComparers.equalityCompare
+            (fun newValueOpt node ->
+                match node.Reference with
+                | ValueNone -> ()
+                | ValueSome viewRef ->
+                    viewRef.Unset()
+                    node.Reference <- ValueNone
+
+                match newValueOpt with
+                | ValueNone -> ()
+                | ValueSome viewRef ->
+                    node.Reference <- ValueSome viewRef
+                    viewRef.Set(node.Target))


### PR DESCRIPTION
I had to remove all `Position` / `PositionChanged` because CarouselView is incredibly buggy if we try to interfere in the position.

Usage
--

```fs
let indicatorViewRef = ViewRef<IndicatorView>()

let view model =
    VStack() {
        (CarouselView(model.Items) (fun item ->
            Label(item)
        )).indicatorView(indicatorViewRef)

        IndicatorView(indicatorViewRef)
            .indicatorColor(Color.Red)
            .selectedIndicatorColor(Color.Blue)
    }
```