### PR TITLE
RelativeLayout + Widget + Extensions

### DIFF
--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="Views\Layouts\ScrollView.fs" />
     <Compile Include="Views\Layouts\Frame.fs" />
     <Compile Include="Views\Layouts\AbsoluteLayout.fs" />
+    <Compile Include="Views\Layouts\RelativeLayout.fs" />
     <Compile Include="Views\Layouts\FlexLayout.fs" />
     <Compile Include="Views\Controls\IndicatorView.fs" />
     <Compile Include="Views\Controls\Label.fs" />

--- a/src/Fabulous.XamarinForms/Views/Layouts/RelativeLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/RelativeLayout.fs
@@ -1,0 +1,75 @@
+namespace Fabulous.XamarinForms
+
+open System
+open System.Runtime.CompilerServices
+open Fabulous
+open Fabulous.XamarinForms
+open Xamarin.Forms
+
+type IRelativeLayout =
+    inherit ILayoutOfView
+
+module RelativeLayout =
+    let WidgetKey = Widgets.register<RelativeLayout> ()
+
+    let XConstraint =
+        Attributes.defineBindable<Constraint> RelativeLayout.XConstraintProperty
+
+    let YConstraint =
+        Attributes.defineBindable<Constraint> RelativeLayout.YConstraintProperty
+
+    let WidthConstraint =
+        Attributes.defineBindable<Constraint> RelativeLayout.WidthConstraintProperty
+
+    let HeightConstraint =
+        Attributes.defineBindable<Constraint> RelativeLayout.HeightConstraintProperty
+
+    let BoundsConstraint =
+        Attributes.defineBindable<BoundsConstraint> RelativeLayout.BoundsConstraintProperty
+
+[<AutoOpen>]
+module RelativeLayoutBuilders =
+    type Fabulous.XamarinForms.View with
+        static member inline RelativeLayout<'msg>() =
+            CollectionBuilder<'msg, IRelativeLayout, IView>(RelativeLayout.WidgetKey, LayoutOfView.Children)
+
+[<Extension>]
+type RelativeLayoutModifiers =
+    /// <summary>Link a ViewRef to access the direct AbsoluteLayout control instance</summary>
+    [<Extension>]
+    static member inline reference(this: WidgetBuilder<'msg, IRelativeLayout>, value: ViewRef<RelativeLayout>) =
+        this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
+
+[<Extension>]
+type RelativeLayoutAttachedModifiers =
+    [<Extension>]
+    static member inline xConstraint(this: WidgetBuilder<'msg, #IView>, value: float) =
+        this.AddScalar(RelativeLayout.XConstraint.WithValue(Constraint.Constant(value)))
+
+    [<Extension>]
+    static member inline xConstraint(this: WidgetBuilder<'msg, #IView>, value: Func<RelativeLayout, float>) =
+        this.AddScalar(RelativeLayout.XConstraint.WithValue(Constraint.RelativeToParent(value)))
+
+    [<Extension>]
+    static member inline yConstraint(this: WidgetBuilder<'msg, #IView>, value: float) =
+        this.AddScalar(RelativeLayout.YConstraint.WithValue(Constraint.Constant(value)))
+
+    [<Extension>]
+    static member inline yConstraint(this: WidgetBuilder<'msg, #IView>, value: Func<RelativeLayout, float>) =
+        this.AddScalar(RelativeLayout.YConstraint.WithValue(Constraint.RelativeToParent(value)))
+
+    [<Extension>]
+    static member inline widthConstraint(this: WidgetBuilder<'msg, #IView>, value: float) =
+        this.AddScalar(RelativeLayout.WidthConstraint.WithValue(Constraint.Constant(value)))
+
+    [<Extension>]
+    static member inline widthConstraint(this: WidgetBuilder<'msg, #IView>, value: Func<RelativeLayout, float>) =
+        this.AddScalar(RelativeLayout.WidthConstraint.WithValue(Constraint.RelativeToParent(value)))
+
+    [<Extension>]
+    static member inline heightConstraint(this: WidgetBuilder<'msg, #IView>, value: float) =
+        this.AddScalar(RelativeLayout.HeightConstraint.WithValue(Constraint.Constant(value)))
+
+    [<Extension>]
+    static member inline heightConstraint(this: WidgetBuilder<'msg, #IView>, value: Func<RelativeLayout, float>) =
+        this.AddScalar(RelativeLayout.HeightConstraint.WithValue(Constraint.RelativeToParent(value)))


### PR DESCRIPTION
This PR adds basic support to match v1 for RelativeLayout based on : https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.relativelayout?view=xamarin-forms

## Not Implemented 

- RelativeToView as we need a way to eg the a reference to the view that we want base the position of our element
```csharp
public static Constraint RelativeToView(View view, Func<RelativeLayout, View, double> measure)
{
	var result = new Constraint { _measureFunc = layout => measure(layout, view), RelativeTo = new[] { view } };

	return result;
}
```

- BoundsConstraint 
```csharp
public static BoundsConstraint FromExpression(Expression<Func<Rectangle>> expression, IEnumerable<View> parents = null)
{
	return FromExpression(expression, false, parents);
}

internal static BoundsConstraint FromExpression(Expression<Func<Rectangle>> expression, bool fromExpression, IEnumerable<View> parents = null)
{
	Func<Rectangle> compiled = expression.Compile();
	var result = new BoundsConstraint
	{
		_measureFunc = compiled,
		RelativeTo = parents ?? ExpressionSearch.Default.FindObjects<View>(expression).ToArray(), // make sure we have our own copy
		CreatedFromExpression = fromExpression
	};

	return result;
}
```

### We could consider using ViewRef to try to accomplish this maybe ? 