### PR TITLE
Focus Extension

### DIFF
--- a/src/Fabulous.XamarinForms/Views/_VisualElement.fs
+++ b/src/Fabulous.XamarinForms/Views/_VisualElement.fs
@@ -85,6 +85,19 @@ module VisualElement =
     let Visual =
         Attributes.defineBindable<IVisual> VisualElement.VisualProperty
 
+    let SetFocus =
+        Attributes.define<bool>
+            "VisualElement_SetFocus"
+            (fun newValueOpt node ->
+                let view = node.Target :?> VisualElement
+
+                match newValueOpt with
+                | ValueNone -> ()
+                | ValueSome isFocused ->
+                    if isFocused then
+                        view.Focus() |> ignore
+                    else
+                        view.Unfocus())
 
     let Focused =
         Attributes.defineEvent<FocusEventArgs>
@@ -221,3 +234,7 @@ type VisualElementModifiers =
     [<Extension>]
     static member inline onUnfocused(this: WidgetBuilder<'msg, #IVisualElement>, onUnfocused: bool -> 'msg) =
         this.AddScalar(VisualElement.Unfocused.WithValue(fun args -> onUnfocused args.IsFocused |> box))
+
+    [<Extension>]
+    static member inline setFocus(this: WidgetBuilder<'msg, #IVisualElement>, value: bool) =
+        this.AddScalar(VisualElement.SetFocus.WithValue(value))


### PR DESCRIPTION
This PR adds a convenient SetFocus extension to Focus(0 in a VisualElement that is not in the Screen and we want to trigger it . 

**BEFORE:** 
    - We have to use the Element ViewRef to be able to the use . and then use a Cmd to perform this interaction
```fsharp
 match loanAmountPickerRef.TryValue with
  | Some target -> target.Focus() |> ignore
  | None -> failwith "LoanAmountPickerRef not found"
 ```

Using this extenion
- Just use .setFocus(model.X) and this will internally handle that for you . You can manage this model as you need
```fsharp
Picker(["1"; "2"], PickerMsg)
    .isVisible(false)
    .setFocus(model.X)
```

https://user-images.githubusercontent.com/31915729/158196819-9546524b-edd9-4227-bf64-1fd49eaee8a9.mp4
