### PR TITLE
Apply ItemTemplate inside DataTemplate instead of ItemsSource

### DIFF
--- a/src/Fabulous.XamarinForms/Views/Collections/CarouselView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/CarouselView.fs
@@ -10,10 +10,7 @@ type ICarouselView =
     inherit IItemsView
 
 module CarouselView =
-
-    let WidgetKey =
-        Widgets.registerWithAdditionalSetup<CarouselView>
-            (fun target node -> target.ItemTemplate <- SimpleWidgetDataTemplateSelector(node))
+    let WidgetKey = Widgets.register<CarouselView> ()
 
     let IsBounceEnabled =
         Attributes.defineBindable<bool> CarouselView.IsBounceEnabledProperty

--- a/src/Fabulous.XamarinForms/Views/Collections/_ItemsViewOfCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/_ItemsViewOfCell.fs
@@ -8,23 +8,22 @@ type IItemsViewOfCell =
 
 module ItemsViewOfCell =
     let ItemsSource<'T> =
-        Attributes.defineBindableWithComparer<WidgetItems<'T>, WidgetItems<'T>, System.Collections.Generic.IEnumerable<Widget>>
-            Xamarin.Forms.ItemsView<Cell>.ItemsSourceProperty
+        Attributes.defineScalarWithConverter<WidgetItems<'T>, WidgetItems<'T>, WidgetItems<'T>>
+            "ItemsViewOfCell_ItemsSource"
             id
-            (fun modelValue ->
-                seq {
-                    for x in modelValue.OriginalItems do
-                        modelValue.Template x
-                })
+            id
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
+            (fun newValueOpt node ->
+                let itemsView = node.Target :?> ItemsView<Cell>
 
-    let GroupedItemsSource<'T> =
-        Attributes.defineBindableWithComparer<GroupedWidgetItems<'T>, GroupedWidgetItems<'T>, System.Collections.Generic.IEnumerable<GroupItem>>
-            Xamarin.Forms.ItemsView<Cell>.ItemsSourceProperty
-            id
-            (fun modelValue ->
-                seq {
-                    for x in modelValue.OriginalItems do
-                        modelValue.Template x
-                })
-            (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
+                match newValueOpt with
+                | ValueNone ->
+                    itemsView.ClearValue(ItemsView<Cell>.ItemTemplateProperty)
+                    itemsView.ClearValue(ItemsView<Cell>.ItemsSourceProperty)
+                | ValueSome value ->
+                    itemsView.SetValue(
+                        ItemsView<Cell>.ItemTemplateProperty,
+                        WidgetDataTemplateSelector(node, unbox >> value.Template)
+                    )
+
+                    itemsView.SetValue(ItemsView<Cell>.ItemsSourceProperty, value.OriginalItems))


### PR DESCRIPTION
The way virtualised collection was handled before conflicted with CarouselView on XF.Android...

Before:
- We applied immediately the item template provided by the user to the items before setting the `ItemsSource` property
- `ItemTemplate` was set to a static `DataTemplateSelector` that only creates the real cell based on the current widget item

After:
- We directly set the items provided by the user to the `ItemsSource` property with no modification
- `ItemTemplate` is set to a dynamic data template selector that first apply the item template function provided by the user before generating the real cell

The issue before is that `CarouselViewRenderer` on Android is actually trying to find the index of an item in the `ItemsSource`. This is fine except `Widget`s generated by Fabulous **are not** equatable so the index will be `-1` is some cases, which is an invalid value.